### PR TITLE
Feature/refactor resource

### DIFF
--- a/ingestify/__init__.py
+++ b/ingestify/__init__.py
@@ -6,6 +6,6 @@ except NameError:
 
 if not __INGESTIFY_SETUP__:
     from .infra import retrieve_http
-    from .source_base import Source
+    from .source_base import Source, DatasetResource
 
 __version__ = "0.0.5"

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -9,6 +9,7 @@ from io import BytesIO, StringIO
 
 from typing import Dict, List, Optional, Union, Callable, BinaryIO
 
+from ingestify.domain.models.dataset.dataset import DatasetState
 from ingestify.domain.models.dataset.events import RevisionAdded, MetadataUpdated
 from ingestify.domain.models.dataset.file_collection import FileCollection
 from ingestify.domain.models.event import EventBus
@@ -209,9 +210,9 @@ class DatasetStore:
     ):
         """The add_revision will also save the dataset."""
         metadata_changed = False
-        if dataset.update_from_identifier(dataset_identifier):
-            self.dataset_repository.save(bucket=self.bucket, dataset=dataset)
-            metadata_changed = True
+        # if dataset.update_from_identifier(dataset_identifier):
+        #     self.dataset_repository.save(bucket=self.bucket, dataset=dataset)
+        #     metadata_changed = True
 
         self.add_revision(dataset, files)
 
@@ -229,6 +230,9 @@ class DatasetStore:
         dataset_type: str,
         provider: str,
         dataset_identifier: Identifier,
+        name: str,
+        state: DatasetState,
+        metadata: dict,
         files: Dict[str, DraftFile],
         description: str = "Create",
     ):
@@ -237,12 +241,12 @@ class DatasetStore:
         dataset = Dataset(
             bucket=self.bucket,
             dataset_id=self.dataset_repository.next_identity(),
-            name=dataset_identifier.name,
-            state=dataset_identifier.state,
+            name=name,
+            state=state,
             identifier=dataset_identifier,
             dataset_type=dataset_type,
             provider=provider,
-            metadata=dataset_identifier.metadata,
+            metadata=metadata,
             created_at=now,
             updated_at=now,
         )

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -17,6 +17,7 @@ from ingestify.domain.models import (
     Dataset,
     DatasetCollection,
     DatasetRepository,
+    DatasetResource,
     DraftFile,
     File,
     LoadedFile,
@@ -205,14 +206,14 @@ class DatasetStore:
     def update_dataset(
         self,
         dataset: Dataset,
-        dataset_identifier: Identifier,
+        dataset_resource: DatasetResource,
         files: Dict[str, DraftFile],
     ):
         """The add_revision will also save the dataset."""
         metadata_changed = False
-        # if dataset.update_from_identifier(dataset_identifier):
-        #     self.dataset_repository.save(bucket=self.bucket, dataset=dataset)
-        #     metadata_changed = True
+        if dataset.update_from_resource(dataset_resource):
+            self.dataset_repository.save(bucket=self.bucket, dataset=dataset)
+            metadata_changed = True
 
         self.add_revision(dataset, files)
 

--- a/ingestify/application/ingestion_engine.py
+++ b/ingestify/application/ingestion_engine.py
@@ -21,8 +21,8 @@ class IngestionEngine:
     def add_extract_job(self, extract_job: ExtractJob):
         self.loader.add_extract_job(extract_job)
 
-    def load(self):
-        self.loader.collect_and_run()
+    def load(self, dry_run: bool = False):
+        self.loader.collect_and_run(dry_run=dry_run)
 
     def list_datasets(self, as_count: bool = False):
         """Consider moving this to DataStore"""

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -25,7 +25,7 @@ else:
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_CHUNK_SIZE = 100
+DEFAULT_CHUNK_SIZE = 1000
 
 
 def to_batches(input_):
@@ -52,7 +52,8 @@ def load_file(
             file_resource.file_id
         )
 
-    if file_resource.json_content:
+    if file_resource.json_content is not None:
+        # Empty dictionary is allowed
         return DraftFile.from_input(
             file_=json.dumps(file_resource.json_content, indent=4),
             data_serialization_format="json",
@@ -93,7 +94,7 @@ class UpdateDatasetTask(Task):
     def run(self):
         self.store.update_dataset(
             dataset=self.dataset,
-            dataset_identifier=Identifier(self.dataset_resource.dataset_resource_id),
+            dataset_resource=self.dataset_resource,
             files={
                 file_id: load_file(file_resource, dataset=self.dataset)
                 for file_id, file_resource in self.dataset_resource.files.items()

--- a/ingestify/cmdline.py
+++ b/ingestify/cmdline.py
@@ -57,8 +57,16 @@ def cli():
     help="bucket",
     type=str,
 )
-@click.option("--debug", "debug", required=False, help="Debugging enabled", type=bool)
-def run(config_file: str, bucket: Optional[str], debug: Optional[bool]):
+# @click.option("--debug", "debug", required=False, help="Debugging enabled", type=bool)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    required=False,
+    help="Dry run - don't store anything",
+    is_flag=True,
+    type=bool,
+)
+def run(config_file: str, bucket: Optional[str], dry_run: Optional[bool]):
     try:
         engine = get_engine(config_file, bucket)
     except ConfigurationError as e:
@@ -68,7 +76,7 @@ def run(config_file: str, bucket: Optional[str], debug: Optional[bool]):
             logger.exception(f"Failed due a configuration error: {e}")
             sys.exit(1)
 
-    engine.load()
+    engine.load(dry_run=dry_run)
 
     logger.info("Done")
 

--- a/ingestify/domain/models/__init__.py
+++ b/ingestify/domain/models/__init__.py
@@ -18,6 +18,7 @@ from .sink import Sink, sink_factory
 from .source import Source
 from .task import Task, TaskSet
 from .data_spec_version_collection import DataSpecVersionCollection
+from .resources import DatasetResource
 
 __all__ = [
     "Selector",
@@ -26,6 +27,7 @@ __all__ = [
     "Revision",
     "Dataset",
     "DatasetCollection",
+    "DatasetResource",
     "File",
     "DraftFile",
     "DatasetCreated",

--- a/ingestify/domain/models/dataset/dataset.py
+++ b/ingestify/domain/models/dataset/dataset.py
@@ -53,18 +53,18 @@ class Dataset:
         self.revisions.append(revision)
         self.updated_at = utcnow()
 
-    def update_from_identifier(self, dataset_identifier: Identifier) -> bool:
+    def update_from_resource(self, dataset_resource) -> bool:
         changed = False
-        if self.name != dataset_identifier.name:
-            self.name = dataset_identifier.name
+        if self.name != dataset_resource.name:
+            self.name = dataset_resource.name
             changed = True
 
-        if self.metadata != dataset_identifier.metadata:
-            self.metadata = dataset_identifier.metadata
+        if self.metadata != dataset_resource.metadata:
+            self.metadata = dataset_resource.metadata
             changed = True
 
-        if self.state != dataset_identifier.state:
-            self.state = dataset_identifier.state
+        if self.state != dataset_resource.state:
+            self.state = dataset_resource.state
             changed = True
 
         if changed:

--- a/ingestify/domain/models/dataset/identifier.py
+++ b/ingestify/domain/models/dataset/identifier.py
@@ -1,33 +1,24 @@
-from datetime import datetime
-from typing import Optional, TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
-from ingestify.utils import AttributeBag
+from ingestify.utils import key_from_dict
 
 if TYPE_CHECKING:
-    from ingestify.domain.models.dataset.dataset import DatasetState
+    from ingestify.domain import Selector
 
 
-class Identifier(AttributeBag):
-    @property
-    def last_modified(self) -> Optional[datetime]:
-        return self.attributes.get("_last_modified")
-
-    @property
-    def name(self) -> Optional[str]:
-        return self.attributes.get("_name")
+class Identifier(dict):
+    @classmethod
+    def create_from_selector(cls, selector: "Selector", **kwargs):
+        identifier = cls(**selector.filtered_attributes)
+        identifier.update(kwargs)
+        return identifier
 
     @property
-    def metadata(self) -> dict:
-        return self.attributes.get("_metadata", {})
+    def key(self):
+        return key_from_dict(self)
 
-    @property
-    def state(self) -> "DatasetState":
-        from ingestify.domain.models.dataset.dataset import DatasetState
+    def __hash__(self):
+        return hash(self.key)
 
-        return self.attributes.get("_state", DatasetState.SCHEDULED)
-
-    @property
-    def files_last_modified(self) -> Optional[Dict[str, datetime]]:
-        """Return last modified per file. This makes it possible to detect when a file is added with an older
-        last_modified than current dataset."""
-        return self.attributes.get("_files_last_modified")
+    def __str__(self):
+        return "/".join([f"{k}={v}" for k, v in self.items()])

--- a/ingestify/domain/models/fetch_policy.py
+++ b/ingestify/domain/models/fetch_policy.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from ingestify.domain import Dataset, Identifier
+from ingestify.domain import Dataset, Identifier, DatasetResource
 from ingestify.utils import utcnow
 
 
@@ -10,25 +10,31 @@ class FetchPolicy:
         self.min_age = utcnow() - timedelta(days=2)
         self.last_change = utcnow() - timedelta(days=1)
 
-    def should_fetch(self, dataset_identifier: Identifier) -> bool:
+    def should_fetch(self, dataset_resource: DatasetResource) -> bool:
         # this is called when dataset does not exist yet
         return True
 
-    def should_refetch(self, dataset: Dataset, identifier: Identifier) -> bool:
+    def should_refetch(
+        self, dataset: Dataset, dataset_resource: DatasetResource
+    ) -> bool:
         current_revision = dataset.current_revision
         if not dataset.revisions:
             # TODO: this is weird? Dataset without any data. Fetch error?
             return True
         elif current_revision:
-            if identifier.files_last_modified:
-                if current_revision.is_changed(identifier.files_last_modified):
-                    return True
+            files_last_modified = {
+                file.file_id: file.last_modified
+                for file in dataset_resource.files.values()
+            }
+            if current_revision.is_changed(files_last_modified):
+                return True
 
-            else:
-                if (
-                    identifier.last_modified
-                    and current_revision.created_at < identifier.last_modified
-                ):
-                    return True
+            # We don't set last_modified on Dataset level anymore, only on file level
+            # else:
+            #     if (
+            #         identifier.last_modified
+            #         and current_revision.created_at < identifier.last_modified
+            #     ):
+            #         return True
 
         return False

--- a/ingestify/domain/models/resources/__init__.py
+++ b/ingestify/domain/models/resources/__init__.py
@@ -1,0 +1,1 @@
+from .dataset_resource import DatasetResource

--- a/ingestify/domain/models/resources/dataset_resource.py
+++ b/ingestify/domain/models/resources/dataset_resource.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ingestify.domain import DraftFile, File
+    from ingestify.domain.models.dataset.dataset import DatasetState
+
+
+@dataclass(frozen=True)
+class FileResource:
+    file_id: str
+    last_modified: datetime
+    data_feed_key: str
+    data_spec_version: str
+
+    # DataSerializationFormat is "json" in case of json_content, otherwise file_loader will return it
+    # data_serialization_format: str
+
+    json_content: Optional[str] = None
+    file_loader: Optional[
+        Callable[
+            ["DatasetResource", "FileResource", Optional["File"]], Optional["DraftFile"]
+        ]
+    ] = None
+
+
+class DatasetResource:
+    def __init__(
+        self, dataset_resource_id: dict, name: str, metadata: dict, state: "DatasetState"
+    ):
+        self.dataset_resource_id = dataset_resource_id
+        self.name = name
+        self.metadata = metadata
+        self.state = state
+
+        self._files = {}
+
+    def add_file_resource(
+        self,
+        last_modified: datetime,
+        data_feed_key: str,
+        data_spec_version: str,
+        json_content: Optional[str] = None,
+        file_loader: Optional[
+            Callable[
+                ["DatasetResource", "FileResource", Optional["File"]], Optional["DraftFile"]
+            ]
+        ] = None,
+    ):
+        file_id = f"{data_feed_key}__{data_spec_version}"
+
+        file_resource = FileResource(
+            file_id=file_id,
+            data_feed_key=data_feed_key,
+            data_spec_version=data_spec_version,
+            last_modified=last_modified,
+            json_content=json_content,
+            file_loader=file_loader,
+        )
+
+        self._files[file_id] = file_resource

--- a/ingestify/domain/models/resources/dataset_resource.py
+++ b/ingestify/domain/models/resources/dataset_resource.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class FileResource:
+    dataset_resource: "DatasetResource"
     file_id: str
     last_modified: datetime
     data_feed_key: str
@@ -17,46 +18,70 @@ class FileResource:
     # DataSerializationFormat is "json" in case of json_content, otherwise file_loader will return it
     # data_serialization_format: str
 
-    json_content: Optional[str] = None
+    json_content: Optional[dict] = None
+
+    url: Optional[str] = None
+    http_options: Optional[dict] = None
+    data_serialization_format: Optional[str] = None
+
     file_loader: Optional[
-        Callable[
-            ["DatasetResource", "FileResource", Optional["File"]], Optional["DraftFile"]
-        ]
+        Callable[["FileResource", Optional["File"]], Optional["DraftFile"]]
     ] = None
 
 
 class DatasetResource:
     def __init__(
-        self, dataset_resource_id: dict, name: str, metadata: dict, state: "DatasetState"
+        self,
+        dataset_resource_id: dict,
+        /,
+        dataset_type: str,
+        provider: str,
+        name: str,
+        metadata: Optional[dict] = None,
+        state: Optional["DatasetState"] = None,
     ):
+        from ingestify.domain.models.dataset.dataset import DatasetState
+
+        self.dataset_type = dataset_type
+        self.provider = provider
         self.dataset_resource_id = dataset_resource_id
         self.name = name
-        self.metadata = metadata
-        self.state = state
+        self.metadata = metadata or {}
+        self.state = state or DatasetState.COMPLETE
 
-        self._files = {}
+        self.files = {}
 
-    def add_file_resource(
+    def add_file(
         self,
         last_modified: datetime,
         data_feed_key: str,
         data_spec_version: str,
-        json_content: Optional[str] = None,
+        json_content: Optional[dict] = None,
+        url: Optional[str] = None,
+        http_options: Optional[dict] = None,
+        data_serialization_format: Optional[str] = None,
         file_loader: Optional[
             Callable[
-                ["DatasetResource", "FileResource", Optional["File"]], Optional["DraftFile"]
+                ["FileResource", Optional["File"]],
+                Optional["DraftFile"],
             ]
         ] = None,
     ):
         file_id = f"{data_feed_key}__{data_spec_version}"
+        if file_id in self.files:
+            raise DuplicateFile(f"File with id {file_id} already exists.")
 
         file_resource = FileResource(
+            dataset_resource=self,
             file_id=file_id,
             data_feed_key=data_feed_key,
             data_spec_version=data_spec_version,
             last_modified=last_modified,
             json_content=json_content,
+            url=url,
+            http_options=http_options,
+            data_serialization_format=data_serialization_format,
             file_loader=file_loader,
         )
 
-        self._files[file_id] = file_resource
+        self.files[file_id] = file_resource

--- a/ingestify/domain/models/source.py
+++ b/ingestify/domain/models/source.py
@@ -7,6 +7,7 @@ from . import DraftFile
 from .data_spec_version_collection import DataSpecVersionCollection
 from .dataset import Identifier, Revision
 from .dataset.collection_metadata import DatasetCollectionMetadata
+from .resources.dataset_resource import DatasetResource
 
 
 class Source(ABC):
@@ -24,23 +25,13 @@ class Source(ABC):
     #     pass
 
     @abstractmethod
-    def discover_datasets(
+    def find_datasets(
         self,
         dataset_type: str,
         data_spec_versions: DataSpecVersionCollection,
         dataset_collection_metadata: DatasetCollectionMetadata,
         **kwargs
-    ) -> Union[List[Dict], Iterator[List[Dict]]]:
-        pass
-
-    @abstractmethod
-    def fetch_dataset_files(
-        self,
-        dataset_type: str,
-        identifier: Identifier,
-        data_spec_versions: DataSpecVersionCollection,
-        current_revision: Optional[Revision],
-    ) -> Dict[str, Optional[DraftFile]]:
+    ) -> Iterator[List[DatasetResource]]:
         pass
 
     def __repr__(self):

--- a/ingestify/domain/models/source.py
+++ b/ingestify/domain/models/source.py
@@ -1,11 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Iterable, Iterator, Union
 
-# from ingestify.utils import ComponentFactory, ComponentRegistry
-
-from . import DraftFile
 from .data_spec_version_collection import DataSpecVersionCollection
-from .dataset import Identifier, Revision
 from .dataset.collection_metadata import DatasetCollectionMetadata
 from .resources.dataset_resource import DatasetResource
 
@@ -13,11 +9,6 @@ from .resources.dataset_resource import DatasetResource
 class Source(ABC):
     def __init__(self, name: str, **kwargs):
         self.name = name
-
-    @property
-    @abstractmethod
-    def provider(self) -> str:
-        pass
 
     # TODO: consider making this required...
     # @abstractmethod

--- a/ingestify/exceptions.py
+++ b/ingestify/exceptions.py
@@ -4,3 +4,7 @@ class IngestifyError(Exception):
 
 class ConfigurationError(IngestifyError):
     pass
+
+
+class DuplicateFile(IngestifyError):
+    pass

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -30,8 +30,6 @@ def parse_value(v):
 
 
 def json_serializer(o):
-    if isinstance(o, Identifier):
-        o = o.filtered_attributes
     return json.dumps(o)
 
 

--- a/ingestify/source_base.py
+++ b/ingestify/source_base.py
@@ -1,6 +1,7 @@
 from ingestify.application.dataset_store import DatasetStore
 from ingestify.domain.models import (
     Dataset,
+    DatasetResource,
     DraftFile,
     File,
     Identifier,
@@ -15,6 +16,7 @@ __all__ = [
     "Source",
     "DatasetStore",
     "Dataset",
+    "DatasetResource",
     "Revision",
     "File",
     "DraftFile",

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import pytz
 
-from ingestify import Source
+from ingestify import Source, DatasetResource
 from ingestify.application.ingestion_engine import IngestionEngine
 from ingestify.domain import (
     Identifier,
@@ -11,6 +11,9 @@ from ingestify.domain import (
     DataSpecVersionCollection,
     DraftFile,
     Revision,
+)
+from ingestify.domain.models.dataset.collection_metadata import (
+    DatasetCollectionMetadata,
 )
 from ingestify.domain.models.extract_job import ExtractJob
 from ingestify.domain.models.fetch_policy import FetchPolicy
@@ -31,49 +34,72 @@ def add_extract_job(engine: IngestionEngine, source: Source, **selector):
     )
 
 
-class SimpleFakeSource(Source):
-    @property
-    def provider(self) -> str:
-        return "fake"
+def file_loader(file_resource, current_file):
+    if file_resource.file_id == "file1__v1":
+        if not current_file:
+            return DraftFile.from_input(
+                "content1",
+            )
+        else:
+            return DraftFile.from_input(
+                "different_content",
+            )
 
-    def discover_datasets(
+    elif file_resource.file_id == "file2__v1":
+        return DraftFile.from_input(
+            "some_content" + str(file_resource.dataset_resource.dataset_resource_id)
+        )
+
+
+class SimpleFakeSource(Source):
+    def find_datasets(
         self,
         dataset_type: str,
         data_spec_versions: DataSpecVersionCollection,
+        dataset_collection_metadata: DatasetCollectionMetadata,
         competition_id,
         season_id,
         **kwargs
     ):
-        return [
+        dataset_resource = DatasetResource(
             dict(
                 competition_id=competition_id,
                 season_id=season_id,
-                _name="Test Dataset",
-                _last_modified=datetime.now(pytz.utc),
-            )
-        ]
+            ),
+            provider="fake",
+            dataset_type="match",
+            name="Test Dataset",
+        )
 
-    def fetch_dataset_files(
-        self,
-        dataset_type: str,
-        identifier: Identifier,
-        data_spec_versions: DataSpecVersionCollection,
-        current_revision: Optional[Revision],
-    ):
-        if current_revision:
-            return {
-                "file1": DraftFile.from_input(
-                    "different_content",
-                ),
-                "file2": DraftFile.from_input("some_content" + identifier.key),
-            }
-        else:
-            return {
-                "file1": DraftFile.from_input(
-                    "content1",
-                ),
-                "file2": DraftFile.from_input("some_content" + identifier.key),
-            }
+        last_modified = datetime.now(pytz.utc)
+
+        dataset_resource.add_file(
+            last_modified=last_modified,
+            data_feed_key="file1",
+            data_spec_version="v1",
+            file_loader=file_loader,
+        )
+        dataset_resource.add_file(
+            last_modified=last_modified,
+            data_feed_key="file2",
+            data_spec_version="v1",
+            file_loader=file_loader,
+        )
+        dataset_resource.add_file(
+            last_modified=last_modified,
+            data_feed_key="file3",
+            data_spec_version="v1",
+            json_content={"test": "some-content"},
+        )
+        # dataset_resource.add_file(
+        #     last_modified=last_modified,
+        #     data_feed_key="file4",
+        #     data_spec_version="v1",
+        #     url="https://raw.githubusercontent.com/statsbomb/open-data/refs/heads/master/data/three-sixty/3788741.json",
+        #     data_serialization_format="json"
+        # )
+
+        yield dataset_resource
 
 
 class BatchSource(Source):
@@ -83,14 +109,11 @@ class BatchSource(Source):
         self.should_stop = False
         self.idx = 0
 
-    @property
-    def provider(self) -> str:
-        return "fake"
-
-    def discover_datasets(
+    def find_datasets(
         self,
         dataset_type: str,
         data_spec_versions: DataSpecVersionCollection,
+        dataset_collection_metadata: DatasetCollectionMetadata,
         competition_id,
         season_id,
         **kwargs
@@ -100,38 +123,35 @@ class BatchSource(Source):
             for i in range(10):
                 match_id = self.idx
                 self.idx += 1
-                item = dict(
-                    competition_id=competition_id,
-                    season_id=season_id,
-                    match_id=match_id,
-                    _name="Test Dataset",
-                    _last_modified=datetime.now(pytz.utc),
+                dataset_resource = DatasetResource(
+                    dict(
+                        competition_id=competition_id,
+                        season_id=season_id,
+                        match_id=match_id,
+                    ),
+                    name="Test dataset",
+                    provider="fake",
+                    dataset_type="match",
                 )
-                items.append(item)
+
+                last_modified = datetime.now(pytz.utc)
+
+                dataset_resource.add_file(
+                    last_modified=last_modified,
+                    data_feed_key="file1",
+                    data_spec_version="v1",
+                    file_loader=file_loader,
+                )
+                dataset_resource.add_file(
+                    last_modified=last_modified,
+                    data_feed_key="file2",
+                    data_spec_version="v1",
+                    file_loader=file_loader,
+                )
+
+                items.append(dataset_resource)
             yield items
             self.callback and self.callback(self.idx)
-
-    def fetch_dataset_files(
-        self,
-        dataset_type: str,
-        identifier: Identifier,
-        data_spec_versions: DataSpecVersionCollection,
-        current_revision: Optional[Revision],
-    ):
-        if current_revision:
-            return {
-                "file1": DraftFile.from_input(
-                    "different_content",
-                ),
-                "file2": DraftFile.from_input("some_content" + identifier.key),
-            }
-        else:
-            return {
-                "file1": DraftFile.from_input(
-                    "content1",
-                ),
-                "file2": DraftFile.from_input("some_content" + identifier.key),
-            }
 
 
 def test_engine(config_file):
@@ -155,7 +175,7 @@ def test_engine(config_file):
     dataset = datasets.first()
     assert dataset.identifier == Identifier(competition_id=1, season_id=2)
     assert len(dataset.revisions) == 2
-    assert len(dataset.revisions[0].modified_files) == 2
+    assert len(dataset.revisions[0].modified_files) == 3
     assert len(dataset.revisions[1].modified_files) == 1
 
     add_extract_job(

--- a/ingestify/utils.py
+++ b/ingestify/utils.py
@@ -13,6 +13,15 @@ import cloudpickle
 from typing_extensions import Self
 
 
+from itertools import islice
+
+
+def chunker(it, size):
+    iterator = iter(it)
+    while chunk := list(islice(iterator, size)):
+        yield chunk
+
+
 def sanitize_exception_message(exception_message):
     """
     Sanitizes an exception message by removing any sensitive information such as passwords.


### PR DESCRIPTION
This changes the api of a `Source`.

The `discover_datasets` is replaced with `find_datasets`.

The `find_datasets` method should `yield` the available `DatasetResource`s. Each `DatasetResource` contains one or more files, and a `FileResource` describes how to load the data. This can be:
1. Already contains the json data via `json_content`
2. Has a `url` defined with optional `http_options`
3. Custom `file_loader` which must accept a `FileResource` and optional `File` (current_file)


Example:
```python
dataset_resource = DatasetResource(
    # Set the Identifier of the Dataset
    dict(
        competition_id=competition_id,
        season_id=season_id,
        match_id=match["match_id"]
    ),
    dataset_type=dataset_type,
    provider=self.provider,
    name=name,
    metadata=match,
    state=state
)

dataset_resource.add_file(
    last_modified=last_modified,
    data_feed_key="match",
    data_spec_version=match_data_spec_version,
    json_content=match
)
```
