### PR TITLE
Accept provider as filter for extractjobs

### DIFF
--- a/ingestify/application/ingestion_engine.py
+++ b/ingestify/application/ingestion_engine.py
@@ -21,8 +21,8 @@ class IngestionEngine:
     def add_extract_job(self, extract_job: ExtractJob):
         self.loader.add_extract_job(extract_job)
 
-    def load(self, dry_run: bool = False):
-        self.loader.collect_and_run(dry_run=dry_run)
+    def load(self, dry_run: bool = False, provider: Optional[str] = None):
+        self.loader.collect_and_run(dry_run=dry_run, provider=provider)
 
     def list_datasets(self, as_count: bool = False):
         """Consider moving this to DataStore"""

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -149,12 +149,19 @@ class Loader:
     def add_extract_job(self, extract_job: ExtractJob):
         self.extract_jobs.append(extract_job)
 
-    def collect_and_run(self, dry_run: bool = False):
+    def collect_and_run(self, dry_run: bool = False, provider: Optional[str] = None):
         total_dataset_count = 0
 
         # First collect all selectors, before discovering datasets
         selectors = {}
         for extract_job in self.extract_jobs:
+            if provider is not None:
+                if extract_job.source.provider != provider:
+                    logger.info(
+                        f"Skipping {extract_job } because provider doesn't match '{provider}'"
+                    )
+                    continue
+
             static_selectors = [
                 selector
                 for selector in extract_job.selectors

--- a/ingestify/cmdline.py
+++ b/ingestify/cmdline.py
@@ -66,7 +66,19 @@ def cli():
     is_flag=True,
     type=bool,
 )
-def run(config_file: str, bucket: Optional[str], dry_run: Optional[bool]):
+@click.option(
+    "--provider",
+    "provider",
+    required=False,
+    help="Provider - only run tasks for a single provider",
+    type=str,
+)
+def run(
+    config_file: str,
+    bucket: Optional[str],
+    dry_run: Optional[bool],
+    provider: Optional[str],
+):
     try:
         engine = get_engine(config_file, bucket)
     except ConfigurationError as e:
@@ -76,7 +88,7 @@ def run(config_file: str, bucket: Optional[str], dry_run: Optional[bool]):
             logger.exception(f"Failed due a configuration error: {e}")
             sys.exit(1)
 
-    engine.load(dry_run=dry_run)
+    engine.load(dry_run=dry_run, provider=provider)
 
     logger.info("Done")
 

--- a/ingestify/domain/models/extract_job.py
+++ b/ingestify/domain/models/extract_job.py
@@ -15,3 +15,9 @@ class ExtractJob:
     fetch_policy: FetchPolicy
     dataset_type: str
     data_spec_versions: DataSpecVersionCollection
+
+    def __repr__(self):
+        return f'<ExtractJob source="{self.source.name}" dataset_type="{self.dataset_type}">'
+
+    def __str__(self):
+        return repr(self)

--- a/ingestify/domain/models/source.py
+++ b/ingestify/domain/models/source.py
@@ -10,6 +10,11 @@ class Source(ABC):
     def __init__(self, name: str, **kwargs):
         self.name = name
 
+    @property
+    @abstractmethod
+    def provider(self) -> str:
+        raise NotImplemented
+
     # TODO: consider making this required...
     # @abstractmethod
     # def discover_selectors(self, dataset_type: str) -> List[Dict]:

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -57,6 +57,8 @@ def file_loader(file_resource, current_file):
 
 
 class SimpleFakeSource(Source):
+    provider = "fake"
+
     def find_datasets(
         self,
         dataset_type: str,
@@ -107,6 +109,8 @@ class SimpleFakeSource(Source):
 
 
 class BatchSource(Source):
+    provider = "batch"
+
     def __init__(self, name, callback):
         super().__init__(name)
         self.callback = callback


### PR DESCRIPTION
When you want to run ingestion for different providers on different nodes, it's required to be able to only run ExtractJobs for a single provider.

With the PR the run cli accepts a `provider` argument, which filters ExtractJobs on its Source provider.