### PR TITLE
Feature/partition key transform

### DIFF
--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -291,20 +291,9 @@ class DatasetStore:
                 continue
 
             def get_stream(file_):
-                revision_id = file_.revision_id
-                if revision_id is None:
-                    revision_id = current_revision.revision_id
-
                 return reader(
                     self.file_repository.load_content(
-                        bucket=self.bucket,
-                        dataset=dataset,
-                        # When file.revision_id is set we must use it.
-                        revision_id=revision_id,
-                        filename=file_.file_id
-                        + "."
-                        + file_.data_serialization_format
-                        + suffix,
+                        bucket=self.bucket, storage_path=file_.storage_path
                     )
                 )
 

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -66,6 +66,7 @@ class DatasetStore:
         dataset_type: Optional[str] = None,
         provider: Optional[str] = None,
         dataset_id: Optional[str] = None,
+        metadata_only: Optional[bool] = False,
         **selector,
     ) -> DatasetCollection:
         if "selector" in selector:
@@ -86,6 +87,7 @@ class DatasetStore:
             dataset_type=dataset_type,
             dataset_id=dataset_id,
             provider=provider,
+            metadata_only=metadata_only,
             selector=selector,
         )
         return dataset_collection

--- a/ingestify/domain/models/dataset/file_repository.py
+++ b/ingestify/domain/models/dataset/file_repository.py
@@ -3,11 +3,34 @@ from pathlib import Path
 from typing import BinaryIO
 
 from .dataset import Dataset
+from ...services.identifier_key_transformer import IdentifierTransformer
 
 
 class FileRepository(ABC):
-    def __init__(self, url: str):
+    def __init__(self, url: str, identifier_transformer: IdentifierTransformer):
         self.base_dir = Path(url.split("://")[1])
+        self.identifier_transformer = identifier_transformer
+
+    def get_write_path(
+        self, bucket: str, dataset: Dataset, revision_id: int, filename: str
+    ) -> Path:
+        # TODO: use the IdentifierKeyTransformer
+        identifier_path = self.identifier_transformer.to_path(
+            provider=dataset.provider,
+            dataset_type=dataset.dataset_type,
+            identifier=dataset.identifier,
+        )
+
+        path = (
+            self.base_dir
+            / bucket
+            / f"provider={dataset.provider}"
+            / f"dataset_type={dataset.dataset_type}"
+            / identifier_path
+            / str(revision_id)
+            / filename
+        )
+        return path
 
     @abstractmethod
     def save_content(
@@ -20,30 +43,17 @@ class FileRepository(ABC):
     ) -> Path:
         pass
 
+    def get_read_path(self, storage_path: str) -> Path:
+        return self.base_dir / storage_path
+
     @abstractmethod
-    def load_content(
-        self, bucket: str, dataset: Dataset, revision_id: int, filename: str
-    ) -> BinaryIO:
+    def load_content(self, storage_path: str) -> BinaryIO:
         pass
 
     @classmethod
     @abstractmethod
     def supports(cls, url: str) -> bool:
         pass
-
-    def get_path(
-        self, bucket: str, dataset: Dataset, revision_id: int, filename: str
-    ) -> Path:
-        path = (
-            self.base_dir
-            / bucket
-            / f"provider={dataset.provider}"
-            / f"dataset_type={dataset.dataset_type}"
-            / str(dataset.identifier)
-            / str(revision_id)
-            / filename
-        )
-        return path
 
     def get_relative_path(self, path: Path) -> Path:
         """Return the relative path to the base of the repository"""

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -227,9 +227,9 @@ class IngestionJob:
                 **self.selector.custom_attributes,
             )
 
-        batches = to_batches(dataset_resources)
-
         finish_task_timer = ingestion_job_summary.start_timing("tasks")
+
+        batches = to_batches(dataset_resources)
 
         while True:
             try:

--- a/ingestify/domain/models/ingestion/ingestion_job_summary.py
+++ b/ingestify/domain/models/ingestion/ingestion_job_summary.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def format_duration(duration: timedelta):
-    return f"{duration.total_seconds():.2}sec"
+    return f"{duration.total_seconds():.2f}sec"
 
 
 class IngestionJobSummary(BaseModel):
@@ -100,6 +100,7 @@ class IngestionJobSummary(BaseModel):
         print("--------------------")
         print(f"  - IngestionPlan:")
         print(f"        Source: {self.source_name}")
+        print(f"        Provider: {self.provider}")
         print(f"        DatasetType: {self.dataset_type}")
         print(f"  - Selector: {self.selector}")
         print(f"  - Timings: ")
@@ -109,14 +110,10 @@ class IngestionJobSummary(BaseModel):
             f"  - Tasks: {len(self.task_summaries)} - {(len(self.task_summaries) / self.duration.total_seconds()):.1f} tasks/sec"
         )
 
-        for status in [
-            TaskStatus.FAILED,
-            TaskStatus.FINISHED,
-            TaskStatus.FINISHED_IGNORED,
-        ]:
-            print(
-                f"    - {status.value.lower()}: {len([task for task in self.task_summaries if task.status == status])}"
-            )
+        print(f"    - Failed tasks: {self.failed_tasks}")
+        print(f"    - Successful tasks: {self.successful_tasks}")
+        print(f"    - Successful ignored tasks: {self.successful_tasks}")
+        print(f"    - Skipped datasets: {self.skipped_datasets}")
         print("--------------------")
 
     def __enter__(self):

--- a/ingestify/domain/services/identifier_key_transformer.py
+++ b/ingestify/domain/services/identifier_key_transformer.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from ingestify.exceptions import IngestifyError
 
@@ -22,7 +22,7 @@ class Transformation(ABC):
         return self.transformation_type == TransformationType.IDENTITY
 
     @abstractmethod
-    def __call__(self, id_key_value: str | int) -> str:
+    def __call__(self, id_key_value: Union[str, int]) -> str:
         pass
 
     @classmethod
@@ -37,7 +37,7 @@ class Transformation(ABC):
 class IdentityTransformation(Transformation):
     transformation_type = TransformationType.IDENTITY
 
-    def __call__(self, id_key_value: str | int) -> str:
+    def __call__(self, id_key_value: Union[str, int]) -> str:
         # Return the original value as a string
         return str(id_key_value)
 
@@ -49,7 +49,7 @@ class BucketTransformation(Transformation):
         self.bucket_size = bucket_size
         self.bucket_count = bucket_count
 
-    def __call__(self, id_key_value: str | int) -> str:
+    def __call__(self, id_key_value: Union[str, int]) -> str:
         if self.bucket_count:
             return str(int(id_key_value) % self.bucket_count)
         elif self.bucket_size:
@@ -70,7 +70,7 @@ class IdentifierTransformer:
         provider: str,
         dataset_type: str,
         id_key: str,
-        transformation: Transformation | dict,
+        transformation: Union[Transformation, dict],
     ):
         """
         Registers a transformation for a specific (provider, dataset_type, id_key).

--- a/ingestify/domain/services/identifier_key_transformer.py
+++ b/ingestify/domain/services/identifier_key_transformer.py
@@ -1,0 +1,111 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Callable, Optional
+
+from ingestify.exceptions import IngestifyError
+
+
+class TransformationType(Enum):
+    IDENTITY = "IDENTITY"
+    BUCKET = "BUCKET"
+    RANGE = "RANGE"
+    CUSTOM = "CUSTOM"
+
+
+class Transformation(ABC):
+    @property
+    @abstractmethod
+    def transformation_type(self) -> TransformationType:
+        pass
+
+    def is_identity(self) -> bool:
+        return self.transformation_type == TransformationType.IDENTITY
+
+    @abstractmethod
+    def __call__(self, id_key_value: str | int) -> str:
+        pass
+
+    @classmethod
+    def from_dict(cls, config: dict) -> "Transformation":
+        type_ = config.pop("type")
+        if type_ == "bucket":
+            return BucketTransformation(**config)
+        else:
+            raise IngestifyError(f"Cannot build Transformation from {config}")
+
+
+class IdentityTransformation(Transformation):
+    transformation_type = TransformationType.IDENTITY
+
+    def __call__(self, id_key_value: str | int) -> str:
+        # Return the original value as a string
+        return str(id_key_value)
+
+
+class BucketTransformation(Transformation):
+    transformation_type = TransformationType.BUCKET
+
+    def __init__(self, bucket_size: int = None, bucket_count: int = None):
+        self.bucket_size = bucket_size
+        self.bucket_count = bucket_count
+
+    def __call__(self, id_key_value: str | int) -> str:
+        if self.bucket_count:
+            return str(int(id_key_value) % self.bucket_count)
+        elif self.bucket_size:
+            bucket_start = int(id_key_value) // self.bucket_size * self.bucket_size
+            bucket_end = bucket_start + self.bucket_size - 1
+            return f"{bucket_start}-{bucket_end}"
+        else:
+            raise IngestifyError("Invalid BucketTransformation")
+
+
+class IdentifierTransformer:
+    def __init__(self):
+        # Mapping of (provider, dataset_type, id_key) to the transformation
+        self.key_transformations: dict[tuple[str, str, str], Transformation] = {}
+
+    def register_transformation(
+        self,
+        provider: str,
+        dataset_type: str,
+        id_key: str,
+        transformation: Transformation | dict,
+    ):
+        """
+        Registers a transformation for a specific (provider, dataset_type, id_key).
+        """
+        if isinstance(transformation, dict):
+            transformation = Transformation.from_dict(transformation)
+
+        self.key_transformations[(provider, dataset_type, id_key)] = transformation
+
+    def get_transformation(
+        self, provider: str, dataset_type: str, id_key: str
+    ) -> Transformation:
+        """
+        Retrieves the transformation for the given column or defaults to identity.
+        """
+        transformation = self.key_transformations.get((provider, dataset_type, id_key))
+        return transformation if transformation else IdentityTransformation()
+
+    def to_path(self, provider: str, dataset_type: str, identifier: dict) -> str:
+        """
+        Transforms the identifier into a path string using registered transformations.
+        For non-identity transformations, includes both transformed and original values,
+        with the transformed value appearing first and including the suffix.
+        """
+        path_parts = []
+        for key, value in identifier.items():
+            transformation = self.get_transformation(provider, dataset_type, key)
+            if not transformation.is_identity():
+                # Non-identity transformation: include both transformed and original
+                transformed_value = transformation(value)
+                suffix = transformation.transformation_type.value.lower()
+                path_parts.append(f"{key}_{suffix}={transformed_value}")
+
+            # Append the original value (either standalone for identity or alongside transformed)
+            path_parts.append(f"{key}={value}")
+
+        # Join the parts with `/` to form the full path
+        return "/".join(path_parts)

--- a/ingestify/infra/store/dataset/sqlalchemy/mapping.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/mapping.py
@@ -229,9 +229,11 @@ mapper_registry.map_imperatively(File, file_table)
 ingestion_job_summary = Table(
     "ingestion_job_summary",
     metadata,
-    Column("ingestion_job_id", String(255), primary_key=True),
+    Column("ingestion_job_summary_id", String(255), primary_key=True),
+    Column("ingestion_job_id", String(255), index=True),
     # From the IngestionPlan
     Column("source_name", String(255)),
+    Column("provider", String(255)),
     Column("dataset_type", String(255)),
     Column(
         "data_spec_versions",
@@ -250,6 +252,7 @@ ingestion_job_summary = Table(
     # Some task counters
     Column("successful_tasks", Integer),
     Column("ignored_successful_tasks", Integer),
+    Column("skipped_datasets", Integer),
     Column("failed_tasks", Integer),
     Column(
         "timings",
@@ -281,9 +284,9 @@ task_summary_table = Table(
     "task_summary",
     metadata,
     Column(
-        "ingestion_job_id",
+        "ingestion_job_summary_id",
         String(255),
-        ForeignKey("ingestion_job_summary.ingestion_job_id"),
+        ForeignKey("ingestion_job_summary.ingestion_job_summary_id"),
         primary_key=True,
     ),
     Column("task_id", Integer, primary_key=True),

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -209,9 +209,7 @@ class SqlAlchemyDatasetRepository(DatasetRepository):
             )
 
         if not metadata_only:
-            dataset_query = apply_query_filter(
-                self.session.query(Dataset)  # .options(joinedload(Dataset.revisions))
-            )
+            dataset_query = apply_query_filter(self.session.query(Dataset))
             datasets = list(dataset_query)
         else:
             datasets = []

--- a/ingestify/infra/store/file/local_file_repository.py
+++ b/ingestify/infra/store/file/local_file_repository.py
@@ -19,14 +19,12 @@ class LocalFileRepository(FileRepository):
         filename: str,
         stream: BinaryIO,
     ) -> Path:
-        path = self.get_path(bucket, dataset, revision_id, filename)
+        path = self.get_write_path(bucket, dataset, revision_id, filename)
         path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(path, "wb") as fp:
             shutil.copyfileobj(stream, fp)
         return path
 
-    def load_content(
-        self, bucket: str, dataset: Dataset, revision_id: int, filename: str
-    ) -> BinaryIO:
-        return open(self.get_path(bucket, dataset, revision_id, filename), "rb")
+    def load_content(self, storage_path: str) -> BinaryIO:
+        return open(self.get_read_path(storage_path), "rb")

--- a/ingestify/infra/store/file/s3_file_repository.py
+++ b/ingestify/infra/store/file/s3_file_repository.py
@@ -8,10 +8,7 @@ from ingestify.domain.models import FileRepository
 
 
 class S3FileRepository(FileRepository):
-    def __init__(self, url):
-        super().__init__(url)
-
-        self._s3 = None
+    _s3 = None
 
     @property
     def s3(self):
@@ -30,16 +27,14 @@ class S3FileRepository(FileRepository):
         filename: str,
         stream: BinaryIO,
     ) -> Path:
-        key = self.get_path(bucket, dataset, revision_id, filename)
+        key = self.get_write_path(bucket, dataset, revision_id, filename)
         s3_bucket = Path(key.parts[0])
 
         self.s3.Object(str(s3_bucket), str(key.relative_to(s3_bucket))).put(Body=stream)
         return key
 
-    def load_content(
-        self, bucket: str, dataset: Dataset, revision_id: int, filename: str
-    ) -> BinaryIO:
-        key = self.get_path(bucket, dataset, revision_id, filename)
+    def load_content(self, storage_path: str) -> BinaryIO:
+        key = self.get_read_path(storage_path)
         s3_bucket = Path(key.parts[0])
         return self.s3.Object(str(s3_bucket), str(key.relative_to(s3_bucket))).get()[
             "Body"

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -304,3 +304,11 @@ def test_ingestion_plan_failing_task(config_file):
 
     items = list(engine.store.dataset_repository.session.query(IngestionJobSummary))
     print(items)
+
+
+def test_change_partition_key_transformer():
+    """When the partition key transformer is changed after a file is written, it
+    must still be possible to read an existing file.
+
+    This probably means we need to use the storage_path for reading.
+    """


### PR DESCRIPTION
Some dataset identifier keys have a high cardinality. This can result in partitions with millions of files. This PR allows to specify a identifier key transformation. The transformation is applied on the dataset identifier key, and then prepended to the path.

For example the `player_id` of Scoutastic can have 1000000 different values. Using a Bucket transform with a `bucket_size=10000` config, every file will be stored under a path like `player_id_bucket=0-9999/player_id=1234` etc.

As the transformations might change over time, we need to use the actual storage location of a file instead of calculation the path when we retrieve it. This allows the transformation to change while we still know where to find the file.