### PR TITLE
Bugfix/remove sqlalchemy mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,23 +205,23 @@ dataset_collection = store.get_dataset_collection(
 store.map(
     lambda dataset: (
         store
-        
-        # As it's related to https://github.com/PySport/kloppy the store can load files using kloppy
-        .load_with_kloppy(dataset)
-        
-        # Convert it into a polars dataframe using all columns in the original data and some more additional ones
-        .to_df(
-            "*", 
-            match_id=dataset.identifier.match_id,
-            competition_id=dataset.identifier.competition_id,
-            season_id=dataset.identifier.season_id, 
-            
+
+            # As it's related to https://github.com/PySport/kloppy the store can load files using kloppy
+            .load_with_kloppy(dataset)
+
+            # Convert it into a polars dataframe using all columns in the original data and some more additional ones
+            .to_df(
+            "*",
+            match_id=dataset.dataset_resource_id.match_id,
+            competition_id=dataset.dataset_resource_id.competition_id,
+            season_id=dataset.dataset_resource_id.season_id,
+
             engine="polars"
         )
-        
-        # Write to parquet format
-        .write_parquet(
-            f"/tmp/files/blaat/{dataset.identifier.match_id}.parquet"
+
+            # Write to parquet format
+            .write_parquet(
+            f"/tmp/files/blaat/{dataset.dataset_resource_id.match_id}.parquet"
         )
     ),
     dataset_collection,

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -297,8 +297,8 @@ class DatasetStore:
                 )
 
             loaded_file = LoadedFile(
-                _stream=get_stream if lazy else get_stream(file),
-                **asdict(file),
+                stream_=get_stream if lazy else get_stream(file),
+                **file.model_dump(),
             )
             files[file.file_id] = loaded_file
         return FileCollection(files, auto_rewind=auto_rewind)

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -58,8 +58,7 @@ class DatasetStore:
             self.event_bus.dispatch(event)
 
     def save_ingestion_job_summary(self, ingestion_job_summary):
-        self.dataset_repository.session.add(ingestion_job_summary)
-        self.dataset_repository.session.commit()
+        self.dataset_repository.save_ingestion_job_summary(ingestion_job_summary)
 
     def get_dataset_collection(
         self,

--- a/ingestify/domain/models/base.py
+++ b/ingestify/domain/models/base.py
@@ -1,22 +1,5 @@
-from functools import partial
-from typing import ClassVar, Any, Optional
-
-import pydantic
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict
 
 
-# class BaseModel(PydanticBaseModel):
-#     model_config = ConfigDict(arbitrary_types_allowed=True)
-#
-#     _sa_instance_state: Optional[dict] = None
-from sqlalchemy.orm import MappedAsDataclass
-
-
-class BaseModel(
-    MappedAsDataclass,
-    # DeclarativeBase,
-    dataclass_callable=partial(
-        pydantic.dataclasses.dataclass, config=ConfigDict(arbitrary_types_allowed=True)
-    ),
-):
-    pass
+class BaseModel(PydanticBaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, from_attributes=True)

--- a/ingestify/domain/models/dataset/dataset.py
+++ b/ingestify/domain/models/dataset/dataset.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from ingestify.utils import utcnow
 from .dataset_state import DatasetState
@@ -23,6 +23,13 @@ class Dataset(BaseModel):
     created_at: datetime
     updated_at: datetime
     revisions: List[Revision] = Field(default_factory=list)
+
+    @field_validator("identifier", mode="before")
+    @classmethod
+    def parse_identifier(cls, value):
+        if not isinstance(value, Identifier):
+            return Identifier(value)
+        return value
 
     @property
     def is_complete(self):

--- a/ingestify/domain/models/dataset/file.py
+++ b/ingestify/domain/models/dataset/file.py
@@ -116,18 +116,18 @@ class LoadedFile(BaseModel):
     data_serialization_format: Optional[str]  # Example: 'json'
     storage_compression_method: Optional[str]  # Example: 'gzip'
     storage_path: Path
-    _stream: Union[BinaryIO, BytesIO, Callable[[], Awaitable[Union[BinaryIO, BytesIO]]]]
+    stream_: Union[BinaryIO, BytesIO, Callable[[], Awaitable[Union[BinaryIO, BytesIO]]]]
     revision_id: Optional[int] = None  # This can be used when a Revision is squashed
 
     def load_stream(self):
-        if callable(self._stream):
-            self._stream = self._stream(self)
+        if callable(self.stream_):
+            self.stream_ = self.stream_(self)
 
     @property
     def stream(self):
-        if callable(self._stream):
+        if callable(self.stream_):
             raise Exception("You should load the stream first using `load_stream`")
-        return self._stream
+        return self.stream_
 
 
 __all__ = ["File", "DraftFile", "LoadedFile"]

--- a/ingestify/domain/models/dataset/revision.py
+++ b/ingestify/domain/models/dataset/revision.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from typing_extensions import TypedDict
 
@@ -32,7 +32,7 @@ class Revision(BaseModel):
     created_at: datetime
     description: str
     modified_files: List[File]
-    source: RevisionSource
+    source: Optional[RevisionSource]
     is_squashed: bool = False
     state: RevisionState = RevisionState.PENDING_VALIDATION
 

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import logging
 import uuid
+from enum import Enum
 from typing import Optional, Iterator
 
 from ingestify import retrieve_http
@@ -213,6 +214,9 @@ class IngestionJob:
         self, store: DatasetStore, task_executor: TaskExecutor
     ) -> Iterator[IngestionJobSummary]:
         is_first_chunk = True
+        ingestion_job_exception = (
+            None  # Indicate if there was an exception during the IngestionJob itself
+        )
         ingestion_job_summary = IngestionJobSummary.new(ingestion_job=self)
         # Process all items in batches. Yield a IngestionJobSummary per batch
 
@@ -230,26 +234,37 @@ class IngestionJob:
         # 1. The discover_datasets returns a list, and the entire list can be processed at once
         # 2. The discover_datasets returns an iterator of batches, in this case we need to process each batch
         with ingestion_job_summary.record_timing("find_datasets"):
-            # Timing might be incorrect as it is an iterator
-            dataset_resources = self.ingestion_plan.source.find_datasets(
-                dataset_type=self.ingestion_plan.dataset_type,
-                data_spec_versions=self.selector.data_spec_versions,
-                dataset_collection_metadata=dataset_collection_metadata,
-                **self.selector.custom_attributes,
-            )
+            try:
+                dataset_resources = self.ingestion_plan.source.find_datasets(
+                    dataset_type=self.ingestion_plan.dataset_type,
+                    data_spec_versions=self.selector.data_spec_versions,
+                    dataset_collection_metadata=dataset_collection_metadata,
+                    **self.selector.custom_attributes,
+                )
+
+                # We need to include the to_batches as that will start the generator
+                batches = to_batches(dataset_resources)
+            except Exception as e:
+                logger.exception("Failed to find datasets")
+
+                ingestion_job_summary.set_exception(e)
+                yield ingestion_job_summary
+                return
 
         finish_task_timer = ingestion_job_summary.start_timing("tasks")
-
-        batches = to_batches(dataset_resources)
 
         while True:
             try:
                 batch = next(batches)
             except StopIteration:
                 break
-            except Exception:
-                # TODO: handle exception on IngestionJob level
-                raise
+            except Exception as e:
+                logger.exception("Failed to fetch next batch")
+
+                finish_task_timer()
+                ingestion_job_summary.set_exception(e)
+                yield ingestion_job_summary
+                return
 
             dataset_identifiers = [
                 Identifier.create_from_selector(

--- a/ingestify/domain/models/task/task_summary.py
+++ b/ingestify/domain/models/task/task_summary.py
@@ -16,7 +16,7 @@ from ingestify.utils import utcnow
 logger = logging.getLogger(__name__)
 
 
-class TaskStatus(str, Enum):
+class TaskState(str, Enum):
     RUNNING = "RUNNING"
     FINISHED = "FINISHED"
     FINISHED_IGNORED = "FINISHED_IGNORED"  # Finished, but didn't produce any new data
@@ -37,7 +37,7 @@ class TaskSummary(BaseModel):
     persisted_file_count: int = 0
     bytes_retrieved: int = 0
     last_modified: Optional[datetime] = None
-    status: TaskStatus = TaskStatus.RUNNING
+    state: TaskState = TaskState.RUNNING
     timings: List[Timing] = Field(default_factory=list)
 
     @field_validator("dataset_identifier", mode="before")
@@ -83,10 +83,10 @@ class TaskSummary(BaseModel):
         try:
             yield task_summary
 
-            task_summary.set_status(TaskStatus.FINISHED)
+            task_summary.set_state(TaskState.FINISHED)
         except Exception as e:
             logger.exception(f"Failed to execute task.")
-            task_summary.set_status(TaskStatus.FAILED)
+            task_summary.set_state(TaskState.FAILED)
 
             # When the error comes from our own code, make sure it will be raised to the highest level
             # raise
@@ -111,8 +111,8 @@ class TaskSummary(BaseModel):
                 file.modified_at for file in revision.modified_files
             )
         else:
-            self.status = TaskStatus.FINISHED_IGNORED
+            self.state = TaskState.FINISHED_IGNORED
 
-    def set_status(self, status: TaskStatus):
-        if self.status == TaskStatus.RUNNING:
-            self.status = status
+    def set_state(self, state: TaskState):
+        if self.state == TaskState.RUNNING:
+            self.state = state

--- a/ingestify/exceptions.py
+++ b/ingestify/exceptions.py
@@ -8,3 +8,7 @@ class ConfigurationError(IngestifyError):
 
 class DuplicateFile(IngestifyError):
     pass
+
+
+class SaveError(IngestifyError):
+    pass

--- a/ingestify/infra/serialization/__init__.py
+++ b/ingestify/infra/serialization/__init__.py
@@ -12,14 +12,15 @@ from ingestify.domain.models.event import DomainEvent
 
 event_types = {
     DatasetCreated.event_type: DatasetCreated,
-    RevisionAdded.event_type: RevisionAdded
+    RevisionAdded.event_type: RevisionAdded,
 }
 
 
 def deserialize(event_dict: dict) -> DomainEvent:
-    event_cls = event_types[event_dict['event_type']]
-    event_dict['dataset']['revisions'] = []
-    event_dict['dataset']['identifier'] = Identifier(**event_dict['dataset']['identifier'])
+    event_cls = event_types[event_dict["event_type"]]
+    event_dict["dataset"]["identifier"] = Identifier(
+        **event_dict["dataset"]["identifier"]
+    )
 
     return event_cls.model_validate(event_dict)
 
@@ -28,5 +29,5 @@ def serialize(event: DomainEvent) -> dict:
     event_dict = event.model_dump(mode="json")
 
     # Make sure event_type is always part of the event_dict. Pydantic might skip it when the type is ClassVar
-    event_dict['event_type'] = event.event_type
+    event_dict["event_type"] = event.event_type
     return event_dict

--- a/ingestify/infra/serialization/__init__.py
+++ b/ingestify/infra/serialization/__init__.py
@@ -7,44 +7,26 @@ from dataclass_factory.schema_helpers import type_checker
 
 from ingestify.domain import DatasetCreated, Identifier
 from ingestify.domain.models.dataset.events import MetadataUpdated, RevisionAdded
-
-isotime_schema = Schema(
-    parser=lambda x: datetime.fromisoformat(x.replace("Z", "+00:00")),  # type: ignore
-    serializer=lambda x: datetime.isoformat(x).replace("+00:00", "Z"),
-)
-
-identifier_schema = Schema(
-    # json.loads(x) for backwards compatibility
-    parser=lambda x: Identifier(x if isinstance(x, dict) else json.loads(x)),
-    serializer=lambda x: dict(x),
-)
-
-factory = Factory(
-    schemas={
-        datetime: isotime_schema,
-        Identifier: identifier_schema,
-        DatasetCreated: Schema(
-            pre_parse=type_checker(DatasetCreated.event_type, "event_type")
-        ),
-        MetadataUpdated: Schema(
-            pre_parse=type_checker(MetadataUpdated.event_type, "event_type")
-        ),
-        RevisionAdded: Schema(
-            pre_parse=type_checker(RevisionAdded.event_type, "event_type")
-        ),
-        # ClipSelectionContent: Schema(pre_parse=type_checker(ClipSelectionContent.content_type, field="contentType")),
-        # TeamInfoImageContent: Schema(pre_parse=type_checker(TeamInfoImageContent.content_type, field="contentType")),
-        # StaticVideoContent: Schema(pre_parse=type_checker(StaticVideoContent.content_type, field="contentType"))
-    },
-    default_schema=Schema(),
-)
-
-T = TypeVar("T")
+from ingestify.domain.models.event import DomainEvent
 
 
-def serialize(data: T, class_: Type[T] = None) -> Any:
-    return factory.dump(data, class_)
+event_types = {
+    DatasetCreated.event_type: DatasetCreated,
+    RevisionAdded.event_type: RevisionAdded
+}
 
 
-def unserialize(data: Any, class_: Type[T]) -> T:
-    return factory.load(data, class_)
+def deserialize(event_dict: dict) -> DomainEvent:
+    event_cls = event_types[event_dict['event_type']]
+    event_dict['dataset']['revisions'] = []
+    event_dict['dataset']['identifier'] = Identifier(**event_dict['dataset']['identifier'])
+
+    return event_cls.model_validate(event_dict)
+
+
+def serialize(event: DomainEvent) -> dict:
+    event_dict = event.model_dump(mode="json")
+
+    # Make sure event_type is always part of the event_dict. Pydantic might skip it when the type is ClassVar
+    event_dict['event_type'] = event.event_type
+    return event_dict

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -137,18 +137,14 @@ class SqlAlchemyDatasetRepository(DatasetRepository):
 
     def _upsert(self, connection: Connection, table: Table, entities: list[dict]):
         dialect = self.session.bind.dialect.name
-        match dialect:
-            case "mysql":
-                from sqlalchemy.dialects.mysql import insert
-
-            case "postgresql":
-                from sqlalchemy.dialects.postgresql import insert
-
-            case "sqlite":
-                from sqlalchemy.dialects.sqlite import insert
-
-            case _:
-                raise IngestifyError(f"Don't know how to do an upsert in {dialect}")
+        if dialect == "mysql":
+            from sqlalchemy.dialects.mysql import insert
+        elif dialect == "postgresql":
+            from sqlalchemy.dialects.postgresql import insert
+        elif dialect == "sqlite":
+            from sqlalchemy.dialects.sqlite import insert
+        else:
+            raise IngestifyError(f"Don't know how to do an upsert in {dialect}")
 
         stmt = insert(table).values(entities)
 

--- a/ingestify/infra/store/dataset/sqlalchemy/tables.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/tables.py
@@ -16,10 +16,11 @@ from sqlalchemy import (
     TypeDecorator,
 )
 
-from ingestify.domain import Identifier, DataSpecVersionCollection
+from ingestify.domain import Identifier, DataSpecVersionCollection, Selector
 from ingestify.domain.models.dataset.dataset import DatasetState
+from ingestify.domain.models.ingestion.ingestion_job_summary import IngestionJobState
 
-from ingestify.domain.models.task.task_summary import Operation, TaskStatus
+from ingestify.domain.models.task.task_summary import Operation, TaskState
 from ingestify.domain.models.timing import Timing
 from ingestify.domain.models.dataset.revision import RevisionState
 
@@ -100,7 +101,7 @@ class RevisionStateString(TypeDecorator):
 
     def process_result_value(self, value, dialect):
         if not value:
-            return value
+            return RevisionState.PENDING_VALIDATION
 
         return RevisionState[value]
 
@@ -118,17 +119,30 @@ class OperationString(TypeDecorator):
         return Operation[value]
 
 
-class TaskStatusString(TypeDecorator):
+class TaskStateString(TypeDecorator):
     impl = String(255)
 
-    def process_bind_param(self, value: TaskStatus, dialect):
+    def process_bind_param(self, value: TaskState, dialect):
         return value.value
 
     def process_result_value(self, value, dialect):
         if not value:
             return value
 
-        return TaskStatus[value]
+        return TaskState[value]
+
+
+class IngestionJobStateString(TypeDecorator):
+    impl = String(255)
+
+    def process_bind_param(self, value: IngestionJobState, dialect):
+        return value.value
+
+    def process_result_value(self, value, dialect):
+        if not value:
+            return value
+
+        return IngestionJobState[value]
 
 
 metadata = MetaData()
@@ -185,7 +199,7 @@ file_table = Table(
     ),
 )
 
-ingestion_job_summary = Table(
+ingestion_job_summary_table = Table(
     "ingestion_job_summary",
     metadata,
     Column("ingestion_job_summary_id", String(255), primary_key=True),
@@ -197,18 +211,25 @@ ingestion_job_summary = Table(
     Column(
         "data_spec_versions",
         JSONType(
-            serializer=lambda data_spec_versions: data_spec_versions.to_dict(),
+            serializer=lambda data_spec_versions: {
+                key: list(value) for key, value in data_spec_versions.items()
+            },
             deserializer=lambda data_spec_versions: DataSpecVersionCollection.from_dict(
                 data_spec_versions
             ),
         ),
     ),
     Column(
-        "selector", JSONType(serializer=lambda selector: selector.filtered_attributes)
+        "selector",
+        JSONType(
+            serializer=lambda selector: selector.filtered_attributes,
+            deserializer=lambda selector: Selector(**selector),
+        ),
     ),
     Column("started_at", TZDateTime(6)),
-    Column("finished_at", TZDateTime(6)),
+    Column("ended_at", TZDateTime(6)),
     # Some task counters
+    Column("state", IngestionJobStateString),
     Column("successful_tasks", Integer),
     Column("ignored_successful_tasks", Integer),
     Column("skipped_datasets", Integer),
@@ -217,7 +238,10 @@ ingestion_job_summary = Table(
         "timings",
         JSONType(
             serializer=lambda timings: [
-                timing.model_dump(mode="json") for timing in timings
+                # Timing is probably already a dictionary. Load it into Timing first, so it can be dumped
+                # in json mode
+                Timing.model_validate(timing).model_dump(mode="json")
+                for timing in timings
             ],
             deserializer=lambda timings: [
                 Timing.model_validate(timing) for timing in timings
@@ -258,12 +282,13 @@ task_summary_table = Table(
     Column("persisted_file_count", Integer),
     Column("bytes_retrieved", Integer),
     Column("last_modified", TZDateTime(6)),
-    Column("status", TaskStatusString),
+    Column("state", TaskStateString),
     Column(
         "timings",
         JSONType(
             serializer=lambda timings: [
-                timing.model_dump(mode="json") for timing in timings
+                Timing.model_validate(timing).model_dump(mode="json")
+                for timing in timings
             ],
             deserializer=lambda timings: [
                 Timing.model_validate(timing) for timing in timings

--- a/ingestify/infra/store/dataset/sqlalchemy/tables.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/tables.py
@@ -1,5 +1,4 @@
 import datetime
-from dataclasses import is_dataclass, asdict
 from pathlib import Path
 from typing import Optional
 
@@ -15,17 +14,12 @@ from sqlalchemy import (
     String,
     Table,
     TypeDecorator,
-    Boolean,
 )
-from sqlalchemy.orm import registry, relationship
 
-from ingestify.domain import Selector, Identifier, DataSpecVersionCollection
-from ingestify.domain.models import Dataset, File, Revision
+from ingestify.domain import Identifier, DataSpecVersionCollection
 from ingestify.domain.models.dataset.dataset import DatasetState
-from ingestify.domain.models.ingestion.ingestion_job_summary import (
-    IngestionJobSummary,
-)
-from ingestify.domain.models.task.task_summary import TaskSummary, Operation, TaskStatus
+
+from ingestify.domain.models.task.task_summary import Operation, TaskStatus
 from ingestify.domain.models.timing import Timing
 from ingestify.domain.models.dataset.revision import RevisionState
 
@@ -137,8 +131,6 @@ class TaskStatusString(TypeDecorator):
         return TaskStatus[value]
 
 
-mapper_registry = registry()
-
 metadata = MetaData()
 
 dataset_table = Table(
@@ -192,39 +184,6 @@ file_table = Table(
         ondelete="CASCADE",
     ),
 )
-
-
-mapper_registry.map_imperatively(
-    Dataset,
-    dataset_table,
-    properties={
-        "revisions": relationship(
-            Revision,
-            backref="dataset",
-            order_by=revision_table.c.revision_id,
-            lazy="selectin",
-            cascade="all, delete-orphan",
-        ),
-    },
-)
-
-mapper_registry.map_imperatively(
-    Revision,
-    revision_table,
-    properties={
-        "modified_files": relationship(
-            File,
-            order_by=file_table.c.file_id,
-            primaryjoin="and_(Revision.revision_id==File.revision_id, Revision.dataset_id==File.dataset_id)",
-            lazy="selectin",
-            cascade="all, delete-orphan",
-        )
-    },
-)
-
-
-mapper_registry.map_imperatively(File, file_table)
-
 
 ingestion_job_summary = Table(
     "ingestion_job_summary",
@@ -316,21 +275,54 @@ task_summary_table = Table(
     # Column("state", RevisionStateString, default=RevisionState.PENDING_VALIDATION),
     # Column("source", JSONType()),
 )
-
-
-mapper_registry.map_imperatively(
-    IngestionJobSummary,
-    ingestion_job_summary,
-    properties={
-        "task_summaries": relationship(
-            TaskSummary,
-            backref="ingestion_job_summary",
-            # order_by=task_summary_table.c.revision_id,
-            lazy="selectin",
-            cascade="all, delete-orphan",
-        ),
-    },
-)
-
-
-mapper_registry.map_imperatively(TaskSummary, task_summary_table)
+#
+#
+# mapper_registry = registry()
+#
+# mapper_registry.map_imperatively(
+#     Dataset,
+#     dataset_table,
+#     properties={
+#         "revisions": relationship(
+#             Revision,
+#             backref="dataset",
+#             order_by=revision_table.c.revision_id,
+#             lazy="selectin",
+#             cascade="all, delete-orphan",
+#         ),
+#     },
+# )
+#
+# mapper_registry.map_imperatively(
+#     Revision,
+#     revision_table,
+#     properties={
+#         "modified_files": relationship(
+#             File,
+#             order_by=file_table.c.file_id,
+#             primaryjoin="and_(Revision.revision_id==File.revision_id, Revision.dataset_id==File.dataset_id)",
+#             lazy="selectin",
+#             cascade="all, delete-orphan",
+#         )
+#     },
+# )
+#
+#
+# mapper_registry.map_imperatively(File, file_table)
+#
+# mapper_registry.map_imperatively(
+#     IngestionJobSummary,
+#     ingestion_job_summary,
+#     properties={
+#         "task_summaries": relationship(
+#             TaskSummary,
+#             backref="ingestion_job_summary",
+#             # order_by=task_summary_table.c.revision_id,
+#             lazy="selectin",
+#             cascade="all, delete-orphan",
+#         ),
+#     },
+# )
+#
+#
+# mapper_registry.map_imperatively(TaskSummary, task_summary_table)

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -9,7 +9,8 @@ from ingestify.domain import (
     Selector,
     DataSpecVersionCollection,
     DraftFile,
-    Dataset, DatasetCreated,
+    Dataset,
+    DatasetCreated,
 )
 from ingestify.domain.models.dataset.collection_metadata import (
     DatasetCollectionMetadata,
@@ -17,9 +18,11 @@ from ingestify.domain.models.dataset.collection_metadata import (
 from ingestify.domain.models.dataset.events import RevisionAdded
 from ingestify.domain.models.ingestion.ingestion_job_summary import (
     IngestionJobSummary,
+    IngestionJobState,
 )
 from ingestify.domain.models.ingestion.ingestion_plan import IngestionPlan
 from ingestify.domain.models.fetch_policy import FetchPolicy
+from ingestify.domain.models.task.task_summary import TaskState
 from ingestify.infra.serialization import serialize, deserialize
 from ingestify.main import get_engine
 
@@ -170,7 +173,7 @@ class BatchSource(Source):
             self.callback and self.callback(self.idx)
 
 
-class FailingSource(Source):
+class FailingLoadSource(Source):
     provider = "fake"
 
     def find_datasets(
@@ -203,6 +206,21 @@ class FailingSource(Source):
                 loader_kwargs={"some_extract_config": "test123"},
             )
         )
+
+
+class FailingJobSource(Source):
+    provider = "fake"
+
+    def find_datasets(
+        self,
+        dataset_type: str,
+        data_spec_versions: DataSpecVersionCollection,
+        dataset_collection_metadata: DatasetCollectionMetadata,
+        competition_id,
+        season_id,
+        **kwargs,
+    ):
+        raise Exception("some failure")
 
 
 def test_engine(config_file):
@@ -243,8 +261,9 @@ def test_engine(config_file):
     # Make sure everything still works with a fresh connection
     engine.store.dataset_repository.session_provider.reset()
 
-    items = list(engine.store.dataset_repository.session.query(IngestionJobSummary))
-    print(items)
+    # TODO: reenable
+    # items = list(engine.store.dataset_repository.session.query(IngestionJobSummary))
+    # print(items)
 
     # Make sure we can load the files
     files = engine.store.load_files(datasets.first(), lazy=True)
@@ -298,20 +317,35 @@ def test_iterator_source(config_file):
         assert len(dataset.revisions) == 2
 
     # Sneaked in an extra test for serialization. This just shouldn't break
-    # s = serialize(datasets.first())
-    # unserialize(s, Dataset)
+    s = serialize(DatasetCreated(dataset=datasets.first()))
+    deserialize(s)
 
 
 def test_ingestion_plan_failing_task(config_file):
     engine = get_engine(config_file, "main")
 
-    source = FailingSource("fake-source")
+    source = FailingLoadSource("fake-source")
 
     add_ingestion_plan(engine, source, competition_id=1, season_id=2)
     engine.load()
 
-    items = list(engine.store.dataset_repository.session.query(IngestionJobSummary))
-    print(items)
+    items = engine.store.dataset_repository.load_ingestion_job_summaries()
+    assert len(items) == 1
+    assert items[0].state == IngestionJobState.FINISHED
+    assert items[0].task_summaries[0].state == TaskState.FAILED
+
+
+def test_ingestion_plan_failing_job(config_file):
+    engine = get_engine(config_file, "main")
+
+    source = FailingJobSource("fake-source")
+
+    add_ingestion_plan(engine, source, competition_id=1, season_id=2)
+    engine.load()
+
+    items = engine.store.dataset_repository.load_ingestion_job_summaries()
+    assert len(items) == 1
+    assert items[0].state == IngestionJobState.FAILED
 
 
 def test_change_partition_key_transformer():
@@ -341,4 +375,4 @@ def test_serde(config_file):
 
         deserialized_event = deserialize(event_dict)
 
-        assert event == deserialized_event
+        assert event.model_dump_json() == deserialized_event.model_dump_json()


### PR DESCRIPTION
Remove the mapping from pydantic models to SQLAlchemy tables. This mapping added required to use pydantic dataclasses, and introduced some magic in the classes itself. This magic prevented deserialization of the `Dataset` (and other models) when those objects were not attached to a sqlalchemy session. 

This decoupling should not happen. 

Therefore, an explicit conversation between pydantic models and sqlalchemy **tables** is introduced. The Repository will manage the tables instead of using sqlalchemy models.