### PR TITLE
Log exception of IngestionJob to timing

### DIFF
--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -270,6 +270,7 @@ class DatasetStore:
             metadata=metadata,
             created_at=now,
             updated_at=now,
+            last_modified_at=None,  # Not known at this moment
         )
         revision = self.add_revision(dataset, files, revision_source, description)
 

--- a/ingestify/application/ingestion_engine.py
+++ b/ingestify/application/ingestion_engine.py
@@ -21,8 +21,13 @@ class IngestionEngine:
     def add_ingestion_plan(self, ingestion_plan: IngestionPlan):
         self.loader.add_ingestion_plan(ingestion_plan)
 
-    def load(self, dry_run: bool = False, provider: Optional[str] = None):
-        self.loader.collect_and_run(dry_run=dry_run, provider=provider)
+    def load(
+        self,
+        dry_run: bool = False,
+        provider: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
+        self.loader.collect_and_run(dry_run=dry_run, provider=provider, source=source)
 
     def list_datasets(self, as_count: bool = False):
         """Consider moving this to DataStore"""

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -29,7 +29,12 @@ class Loader:
     def add_ingestion_plan(self, ingestion_plan: IngestionPlan):
         self.ingestion_plans.append(ingestion_plan)
 
-    def collect_and_run(self, dry_run: bool = False, provider: Optional[str] = None):
+    def collect_and_run(
+        self,
+        dry_run: bool = False,
+        provider: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
         # First collect all selectors, before discovering datasets
         selectors = {}
         for ingestion_plan in self.ingestion_plans:
@@ -39,6 +44,13 @@ class Loader:
                 if ingestion_plan.source.provider != provider:
                     logger.info(
                         f"Skipping {ingestion_plan} because provider doesn't match '{provider}'"
+                    )
+                    continue
+
+            if source is not None:
+                if ingestion_plan.source.name != source:
+                    logger.info(
+                        f"Skipping {ingestion_plan} because source doesn't match '{source}'"
                     )
                     continue
 

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -60,6 +60,7 @@ class Loader:
 
                     # TODO: consider making this lazy and fetch once per Source instead of
                     #       once per IngestionPlan
+                    # TODO: Log exception when `discover_selectors` fails
                     all_selectors = ingestion_plan.source.discover_selectors(
                         ingestion_plan.dataset_type
                     )

--- a/ingestify/cmdline.py
+++ b/ingestify/cmdline.py
@@ -58,7 +58,14 @@ def cli():
     help="bucket",
     type=str,
 )
-@click.option("--debug", "debug", required=False, help="Debugging enabled", type=bool)
+@click.option(
+    "--debug",
+    "debug",
+    required=False,
+    help="Debugging enabled",
+    is_flag=True,
+    type=bool,
+)
 @click.option(
     "--dry-run",
     "dry_run",
@@ -74,11 +81,19 @@ def cli():
     help="Provider - only run tasks for a single provider",
     type=str,
 )
+@click.option(
+    "--source",
+    "source",
+    required=False,
+    help="Source - only run tasks for a single source",
+    type=str,
+)
 def run(
     config_file: str,
     bucket: Optional[str],
     dry_run: Optional[bool],
     provider: Optional[str],
+    source: Optional[str],
     debug: Optional[bool],
 ):
     try:
@@ -90,7 +105,10 @@ def run(
             logger.exception(f"Failed due a configuration error: {e}")
             sys.exit(1)
 
-    engine.load(dry_run=dry_run, provider=provider)
+    if debug:
+        logging.getLogger("root").setLevel(logging.DEBUG)
+
+    engine.load(dry_run=dry_run, provider=provider, source=source)
 
     logger.info("Done")
 

--- a/ingestify/domain/models/dataset/collection_metadata.py
+++ b/ingestify/domain/models/dataset/collection_metadata.py
@@ -6,7 +6,8 @@ from typing import Optional
 @dataclass
 class DatasetCollectionMetadata:
     # This can be useful to figure out if a backfill is required
-    first_modified: Optional[datetime]
+    # TODO - Note: not stored at Dataset level and requires joined query to retrieve
+    # first_modified: Optional[datetime]
 
     # Use the last modified to only retrieve datasets that are changed
     last_modified: Optional[datetime]

--- a/ingestify/domain/models/dataset/dataset.py
+++ b/ingestify/domain/models/dataset/dataset.py
@@ -22,7 +22,10 @@ class Dataset(BaseModel):
     metadata: dict
     created_at: datetime
     updated_at: datetime
+
     revisions: List[Revision] = Field(default_factory=list)
+    # The last_modified_at is equal to the max modified_at of all files in all revisions
+    last_modified_at: Optional[datetime]
 
     @field_validator("identifier", mode="before")
     @classmethod
@@ -41,6 +44,13 @@ class Dataset(BaseModel):
     def add_revision(self, revision: Revision):
         self.revisions.append(revision)
         self.updated_at = utcnow()
+
+        if self.last_modified_at:
+            self.last_modified_at = max(
+                self.last_modified_at, revision.last_modified_at
+            )
+        else:
+            self.last_modified_at = revision.last_modified_at
 
     def update_metadata(self, name: str, metadata: dict, state: DatasetState) -> bool:
         changed = False

--- a/ingestify/domain/models/dataset/revision.py
+++ b/ingestify/domain/models/dataset/revision.py
@@ -37,6 +37,10 @@ class Revision(BaseModel):
     state: RevisionState = RevisionState.PENDING_VALIDATION
 
     @property
+    def last_modified_at(self):
+        return max(file.modified_at for file in self.modified_files)
+
+    @property
     def modified_files_map(self) -> Dict[str, File]:
         return {file.file_id: file for file in self.modified_files}
 

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -221,6 +221,7 @@ class IngestionJob:
         with ingestion_job_summary.record_timing("get_dataset_collection"):
             dataset_collection_metadata = store.get_dataset_collection(
                 dataset_type=self.ingestion_plan.dataset_type,
+                provider=self.ingestion_plan.source.provider,
                 data_spec_versions=self.selector.data_spec_versions,
                 selector=self.selector,
                 metadata_only=True,

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -214,9 +214,6 @@ class IngestionJob:
         self, store: DatasetStore, task_executor: TaskExecutor
     ) -> Iterator[IngestionJobSummary]:
         is_first_chunk = True
-        ingestion_job_exception = (
-            None  # Indicate if there was an exception during the IngestionJob itself
-        )
         ingestion_job_summary = IngestionJobSummary.new(ingestion_job=self)
         # Process all items in batches. Yield a IngestionJobSummary per batch
 
@@ -233,8 +230,8 @@ class IngestionJob:
         # There are two different, but similar flows here:
         # 1. The discover_datasets returns a list, and the entire list can be processed at once
         # 2. The discover_datasets returns an iterator of batches, in this case we need to process each batch
-        with ingestion_job_summary.record_timing("find_datasets"):
-            try:
+        try:
+            with ingestion_job_summary.record_timing("find_datasets"):
                 dataset_resources = self.ingestion_plan.source.find_datasets(
                     dataset_type=self.ingestion_plan.dataset_type,
                     data_spec_versions=self.selector.data_spec_versions,
@@ -244,12 +241,12 @@ class IngestionJob:
 
                 # We need to include the to_batches as that will start the generator
                 batches = to_batches(dataset_resources)
-            except Exception as e:
-                logger.exception("Failed to find datasets")
+        except Exception as e:
+            logger.exception("Failed to find datasets")
 
-                ingestion_job_summary.set_exception(e)
-                yield ingestion_job_summary
-                return
+            ingestion_job_summary.set_exception(e)
+            yield ingestion_job_summary
+            return
 
         finish_task_timer = ingestion_job_summary.start_timing("tasks")
 

--- a/ingestify/domain/models/ingestion/ingestion_job_summary.py
+++ b/ingestify/domain/models/ingestion/ingestion_job_summary.py
@@ -84,6 +84,11 @@ class IngestionJobSummary(BaseModel, HasTiming):
         )
         self.ended_at = utcnow()
 
+        # Only keep failed tasks. Rest isn't interesting
+        self.task_summaries = [
+            task for task in self.task_summaries if task.state == TaskState.FAILED
+        ]
+
     def set_finished(self):
         self.state = IngestionJobState.FINISHED
         self._set_ended()

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -320,10 +320,9 @@ class SqlAlchemyDatasetRepository(DatasetRepository):
 
         metadata_result_row = apply_query_filter(
             self.session.query(
-                func.min(file_table.c.modified_at).label("first_modified_at"),
-                func.max(file_table.c.modified_at).label("last_modified_at"),
+                func.max(dataset_table.c.last_modified_at).label("last_modified_at"),
                 func.count().label("row_count"),
-            ).join(dataset_table, dataset_table.c.dataset_id == file_table.c.dataset_id)
+            )
         ).first()
         dataset_collection_metadata = DatasetCollectionMetadata(*metadata_result_row)
 

--- a/ingestify/infra/store/dataset/sqlalchemy/tables.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/tables.py
@@ -33,16 +33,16 @@ def JSONType(serializer=None, deserializer=None, base_type=JSON):
         impl = base_type
 
         def process_bind_param(self, value, dialect):
-            if serializer is not None:
+            if serializer and value is not None:
                 return serializer(value)
             return value
 
         def process_result_value(self, value, dialect):
-            if deserializer is not None:
+            if deserializer and value is not None:
                 return deserializer(value)
             return value
 
-    return _JsonType()
+    return _JsonType
 
 
 class TZDateTime(TypeDecorator):
@@ -161,14 +161,12 @@ dataset_table = Table(
     Column(
         "identifier",
         # Use JSONB when available
-        JSONType(deserializer=lambda item: Identifier(**item),).with_variant(
-            JSONType(deserializer=lambda item: Identifier(**item), base_type=JSONB),
-            "postgresql",
-        ),
+        JSON().with_variant(JSONB(), "postgresql"),
     ),
     Column("metadata", JSON),
     Column("created_at", TZDateTime(6)),
     Column("updated_at", TZDateTime(6)),
+    Column("last_modified_at", TZDateTime(6)),
 )
 
 revision_table = Table(

--- a/ingestify/infra/store/dataset/sqlalchemy/tables.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/tables.py
@@ -158,17 +158,13 @@ dataset_table = Table(
     Column("dataset_type", String(255), index=True),
     Column("state", DatasetStateString),
     Column("name", String(255)),
-    Column("identifier",
+    Column(
+        "identifier",
         # Use JSONB when available
-        JSONType(
-            deserializer=lambda item: Identifier(**item),
-        ).with_variant(
-            JSONType(
-                deserializer=lambda item: Identifier(**item),
-                base_type=JSONB
-            ),
-            "postgresql"
-        )
+        JSONType(deserializer=lambda item: Identifier(**item),).with_variant(
+            JSONType(deserializer=lambda item: Identifier(**item), base_type=JSONB),
+            "postgresql",
+        ),
     ),
     Column("metadata", JSON),
     Column("created_at", TZDateTime(6)),

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -272,6 +272,8 @@ def test_engine(config_file):
     files = engine.store.load_files(datasets.first(), lazy=False)
     assert files.get_file("file1").stream.read() == b"content1"
 
+    assert dataset.last_modified_at is not None
+
 
 def test_iterator_source(config_file):
     """Test when a Source returns a Iterator to do Batch processing.

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -347,6 +347,10 @@ def test_ingestion_plan_failing_job(config_file):
     assert len(items) == 1
     assert items[0].state == IngestionJobState.FAILED
 
+    # The timing of second task should contain the exception
+    assert items[0].timings[1].metadata["result"]["message"] == "some failure"
+    assert items[0].timings[1].metadata["result"]["type"] == "Exception"
+
 
 def test_change_partition_key_transformer():
     """When the partition key transformer is changed after a file is written, it

--- a/ingestify/utils.py
+++ b/ingestify/utils.py
@@ -221,6 +221,9 @@ class HasTiming:
     def record_timing(
         self, description: str, metadata: Optional[dict] = None
     ) -> Timing:
+        if not metadata:
+            metadata = {}
+
         start = utcnow()
         try:
             result = None

--- a/ingestify/utils.py
+++ b/ingestify/utils.py
@@ -1,6 +1,3 @@
-import abc
-import asyncio
-import inspect
 import logging
 import os
 import time
@@ -11,19 +8,7 @@ from multiprocessing import get_context, cpu_count, get_all_start_methods
 
 from datetime import datetime, timezone
 from string import Template
-from typing import (
-    Dict,
-    Generic,
-    Type,
-    TypeVar,
-    Tuple,
-    Optional,
-    Any,
-    Callable,
-    Awaitable,
-    List,
-    Iterable,
-)
+from typing import Dict, Tuple, Optional, Any, List
 
 import cloudpickle
 from pydantic import Field
@@ -233,10 +218,9 @@ class HasTiming:
     timings: List[Timing] = Field(default_factory=list)
 
     @contextmanager
-    def record_timing(self, description: str, metadata: dict = None) -> Timing:
-        if not metadata:
-            metadata = {}
-
+    def record_timing(
+        self, description: str, metadata: Optional[dict] = None
+    ) -> Timing:
         start = utcnow()
         try:
             result = None

--- a/ingestify/utils.py
+++ b/ingestify/utils.py
@@ -5,6 +5,8 @@ import logging
 import os
 import time
 import re
+import traceback
+from contextlib import contextmanager
 from multiprocessing import get_context, cpu_count, get_all_start_methods
 
 from datetime import datetime, timezone
@@ -24,11 +26,13 @@ from typing import (
 )
 
 import cloudpickle
+from pydantic import Field
 from typing_extensions import Self
 
 
 from itertools import islice
 
+from ingestify.domain.models.timing import Timing
 
 logger = logging.getLogger(__name__)
 
@@ -221,3 +225,44 @@ def try_number(s: str):
             return float(s)
         except ValueError:
             return s
+
+
+class HasTiming:
+    """Mixin to give Pydantic models ability to time actions."""
+
+    timings: List[Timing] = Field(default_factory=list)
+
+    @contextmanager
+    def record_timing(self, description: str, metadata: dict = None) -> Timing:
+        if not metadata:
+            metadata = {}
+
+        start = utcnow()
+        try:
+            result = None
+            yield
+        except Exception as e:
+            result = {
+                "type": type(e).__name__,
+                "message": str(e),
+                "traceback": traceback.format_exc(),
+            }
+            raise e
+        finally:
+            metadata = dict(result=result, **metadata)
+            self.timings.append(
+                Timing(
+                    name=description,
+                    started_at=start,
+                    ended_at=utcnow(),
+                    metadata=metadata,
+                )
+            )
+
+    def start_timing(self, name):
+        start = utcnow()
+
+        def finish():
+            self.timings.append(Timing(name=name, started_at=start, ended_at=utcnow()))
+
+        return finish


### PR DESCRIPTION
- This bugfix (branch named incorrect) makes sure that exceptions during the `find_datasets` is logged correctly.
- Make sure the `--debug` cli flag works and sets the root logger level to `debug`
- Store the `last_modified_at` datetime at `Dateset` level to increase performance of fetching metadata. Otherwise a join between `Dataset` and `File` was required to retrieve last modified based on a `Selector`. 

Additional queries needed:
```sql

ALTER TABLE dataset
ADD COLUMN last_modified_at TIMESTAMPTZ(6);

UPDATE dataset
SET last_modified_at = (
    SELECT MAX(modified_at)
    FROM file
    WHERE file.dataset_id = dataset.dataset_id
);
```