### PR TITLE
Decrease batch size to 500 as that's the limit of compound select statements in sqlite

### DIFF
--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -24,7 +24,9 @@ from ingestify.utils import TaskExecutor, chunker
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_CHUNK_SIZE = 1_000
+# Decrease batch size from 1_000 to 500. The sqlalchemy repository uses
+# a compound select, which breaks at more than 500 select statements
+DEFAULT_CHUNK_SIZE = 500
 
 
 def run_task(task):


### PR DESCRIPTION
One step in Ingestify is to check for existing datasets. A lookup query is done based on the Identifier of the DatasetResources (returned by the Source). A compound select is used to create a temporary table, and join the temporary table. This way the database engine can use indexes.

Normally we do lookups in batches of 1000. But sqlite is limited by the number of compound select statements: https://stackoverflow.com/questions/9527851/sqlite-error-too-many-terms-in-compound-select

