### PR TITLE
Feat/dev engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,43 @@ Ingestify fixes that by building **your own data lake** of untouched provider fi
 pip install ingestify            # or: pip install git+https://github.com/PySport/ingestify.git
 ```
 
+### Developing a new Source
+
+When developing a new `Source`, use the `debug_source()` helper for rapid iteration:
+
+```python
+from ingestify import Source, debug_source
+
+class MyCustomSource(Source):
+    provider = "my_provider"
+
+    def __init__(self, name: str, api_key: str):
+        super().__init__(name)
+        self.api_key = api_key
+
+    def find_datasets(self, dataset_type, data_spec_versions, **kwargs):
+        # Your source implementation
+        ...
+
+# Quick debug - runs full ingestion with temp storage
+if __name__ == "__main__":
+    source = MyCustomSource(name="test", api_key="...")
+
+    debug_source(
+        source,
+        dataset_type="match",
+        data_spec_versions={"events": "v1"},
+    )
+```
+
+The `debug_source()` helper:
+- ✅ Creates an ephemeral dev engine with temp storage
+- ✅ Configures logging automatically
+- ✅ Runs the full ingestion cycle
+- ✅ Shows storage location and results
+
+Perfect for testing your source before adding it to production config!
+
 ### Minimal `config.yaml`
 
 ```yaml

--- a/ingestify/__init__.py
+++ b/ingestify/__init__.py
@@ -7,5 +7,6 @@ except NameError:
 if not __INGESTIFY_SETUP__:
     from .infra import retrieve_http
     from .source_base import Source, DatasetResource
+    from .main import debug_source
 
 __version__ = "0.7.0"

--- a/ingestify/__init__.py
+++ b/ingestify/__init__.py
@@ -9,4 +9,4 @@ if not __INGESTIFY_SETUP__:
     from .source_base import Source, DatasetResource
     from .main import debug_source
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/ingestify/application/ingestion_engine.py
+++ b/ingestify/application/ingestion_engine.py
@@ -110,6 +110,9 @@ class IngestionEngine:
         else:
             do_load()
 
+    # Alias for load() - more intuitive name for running ingestion
+    run = load
+
     def list_datasets(self, as_count: bool = False):
         """Consider moving this to DataStore"""
         datasets = sorted(

--- a/ingestify/main.py
+++ b/ingestify/main.py
@@ -279,3 +279,124 @@ def get_engine(
         ingestion_engine.add_ingestion_plan(ingestion_plan_)
 
     return ingestion_engine
+
+
+def get_dev_engine(
+    source: Source,
+    dataset_type: str,
+    data_spec_versions: dict,
+    ephemeral: bool = True,
+    configure_logging: bool = True,
+) -> IngestionEngine:
+    """
+    Quick development helper - creates an engine with minimal setup.
+
+    Args:
+        source: The source to test
+        dataset_type: Dataset type to ingest
+        data_spec_versions: Dict like {"hops": "v1"}
+        ephemeral: If True, uses temp dir that gets cleaned. If False, uses persistent /tmp storage.
+        configure_logging: If True, configures basic logging (default: True)
+
+    Returns:
+        IngestionEngine configured for development
+
+    Example:
+        >>> source = MySource(name="test", ...)
+        >>> engine = get_dev_engine(source, "hops", {"hops": "v1"})
+        >>> engine.run()
+        >>>
+        >>> # Access the datasets
+        >>> datasets = engine.store.get_dataset_collection()
+        >>> print(f"Ingested {len(datasets)} datasets")
+    """
+    import tempfile
+    from pathlib import Path
+
+    if configure_logging:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+
+    if ephemeral:
+        # Use temp directory that will be cleaned up
+        import uuid
+
+        dev_dir = Path(tempfile.gettempdir()) / f"ingestify-dev-{uuid.uuid4().hex[:8]}"
+    else:
+        # Use persistent directory
+        dev_dir = Path(tempfile.gettempdir()) / "ingestify-dev"
+
+    dev_dir.mkdir(parents=True, exist_ok=True)
+    metadata_url = f"sqlite:///{dev_dir / 'database.db'}"
+    file_url = f"file://{dev_dir}"
+
+    logger.info(f"Dev mode: storing data in {dev_dir}")
+
+    engine = get_engine(
+        metadata_url=metadata_url,
+        file_url=file_url,
+        bucket="main",
+        disable_events=True,
+    )
+
+    data_spec_versions_obj = DataSpecVersionCollection.from_dict(data_spec_versions)
+
+    engine.add_ingestion_plan(
+        IngestionPlan(
+            source=source,
+            dataset_type=dataset_type,
+            selectors=[Selector.build({}, data_spec_versions=data_spec_versions_obj)],
+            fetch_policy=FetchPolicy(),
+            data_spec_versions=data_spec_versions_obj,
+        )
+    )
+
+    return engine
+
+
+def debug_source(
+    source: Source,
+    *,
+    dataset_type: str,
+    data_spec_versions: dict,
+    ephemeral: bool = True,
+    configure_logging: bool = True,
+    **kwargs,
+):
+    """
+    Debug helper - creates a dev engine, runs ingestion, and shows results.
+
+    This is a convenience wrapper around get_dev_engine() that does everything:
+    creates the engine, runs ingestion, and displays results.
+
+    Args:
+        source: The source to debug
+        dataset_type: Dataset type (e.g., "hops", "match")
+        data_spec_versions: Dict like {"hops": "v1"} - explicit, no defaults!
+        ephemeral: If True, uses temp dir. If False, uses persistent /tmp storage.
+        configure_logging: If True, configures basic logging (default: True)
+        **kwargs: Additional selector arguments passed to engine.run()
+
+    Example:
+        >>> source = StatsBombHOPSS3(name="test", s3_bucket="my-bucket", s3_prefix="HOPS")
+        >>> debug_source(source, dataset_type="hops", data_spec_versions={"hops": "v1"})
+    """
+    logger.info(f"Debug mode for source: {source.name}")
+
+    engine = get_dev_engine(
+        source=source,
+        dataset_type=dataset_type,
+        data_spec_versions=data_spec_versions,
+        ephemeral=ephemeral,
+        configure_logging=configure_logging,
+    )
+
+    engine.run(**kwargs)
+
+    # Show results
+    datasets = engine.store.get_dataset_collection()
+    logger.info("=" * 60)
+    logger.info(f"✓ Ingestion complete: {len(datasets)} dataset(s)")
+    logger.info("=" * 60)

--- a/ingestify/tests/test_engine.py
+++ b/ingestify/tests/test_engine.py
@@ -24,7 +24,7 @@ from ingestify.domain.models.ingestion.ingestion_plan import IngestionPlan
 from ingestify.domain.models.fetch_policy import FetchPolicy
 from ingestify.domain.models.task.task_summary import TaskState
 from ingestify.infra.serialization import serialize, deserialize
-from ingestify.main import get_engine
+from ingestify.main import get_engine, get_dev_engine
 
 
 def add_ingestion_plan(engine: IngestionEngine, source: Source, **selector):
@@ -417,3 +417,21 @@ def test_empty_dataset_resource_id(config_file):
 
     add_ingestion_plan(engine, EmptyDatasetResourceIdSource("fake-source"))
     engine.load()
+
+
+def test_dev_engine():
+    """Test dev engine helper for easy development without config file"""
+    source = SimpleFakeSource("test-source")
+
+    engine = get_dev_engine(
+        source=source,
+        dataset_type="match",
+        data_spec_versions={"default": "v1"},
+        ephemeral=True,
+    )
+
+    engine.run(competition_id=1, season_id=2)
+
+    datasets = engine.store.get_dataset_collection()
+    assert len(datasets) == 1
+    assert datasets.first().name == "Test Dataset"


### PR DESCRIPTION
## Add `debug_source()` helper for easy source development

Adds a new `debug_source()` function that simplifies testing and debugging sources during development.

**Key features:**
- Single function call to test any source with minimal setup
- Automatic ephemeral storage in `/tmp` (or persistent if needed)
- Auto-configures logging
- Returns engine for further inspection
- Works with both simple sources and those using `discover_selectors()`

**Example usage:**
```python
from ingestify import debug_source

source = MySource(name="test", ...)
engine = debug_source(
    source,
    dataset_type="match",
    data_spec_versions={"match": "v1"}
)
```

**Also includes:**
- `engine.run()` alias for `engine.load()` (more intuitive)
- Optional `dev_dir` parameter for custom storage location
- Updated README with development workflow guide

Replaces boilerplate setup code in every source file with a single helper function.