### PR TITLE
Add fast skip pre-check to avoid loading full datasets for up-to-date entries

### DIFF
--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -190,6 +190,13 @@ class DatasetStore:
     def save_ingestion_job_summary(self, ingestion_job_summary):
         self.dataset_repository.save_ingestion_job_summary(ingestion_job_summary)
 
+    def get_existing_dataset_timestamps(self, provider: str, dataset_type: str) -> dict:
+        return self.dataset_repository.get_existing_dataset_timestamps(
+            bucket=self.bucket,
+            provider=provider,
+            dataset_type=dataset_type,
+        )
+
     def get_dataset_collection(
         self,
         dataset_type: Optional[str] = None,

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -190,7 +190,9 @@ class DatasetStore:
     def save_ingestion_job_summary(self, ingestion_job_summary):
         self.dataset_repository.save_ingestion_job_summary(ingestion_job_summary)
 
-    def get_dataset_last_modified_at_map(self, provider: str, dataset_type: str) -> dict:
+    def get_dataset_last_modified_at_map(
+        self, provider: str, dataset_type: str
+    ) -> "DatasetLastModifiedAtMap":
         return self.dataset_repository.get_dataset_last_modified_at_map(
             bucket=self.bucket,
             provider=provider,

--- a/ingestify/application/dataset_store.py
+++ b/ingestify/application/dataset_store.py
@@ -190,8 +190,8 @@ class DatasetStore:
     def save_ingestion_job_summary(self, ingestion_job_summary):
         self.dataset_repository.save_ingestion_job_summary(ingestion_job_summary)
 
-    def get_existing_dataset_timestamps(self, provider: str, dataset_type: str) -> dict:
-        return self.dataset_repository.get_existing_dataset_timestamps(
+    def get_dataset_last_modified_at_map(self, provider: str, dataset_type: str) -> dict:
+        return self.dataset_repository.get_dataset_last_modified_at_map(
             bucket=self.bucket,
             provider=provider,
             dataset_type=dataset_type,

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -243,7 +243,7 @@ class Loader:
 
         # Build a cache of existing dataset timestamps per (provider, dataset_type).
         # Used as a fast pre-check to skip datasets that are already up-to-date.
-        existing_timestamps_cache: dict[tuple, dict] = {}
+        last_modified_at_cache: dict[tuple, dict] = {}
 
         for ingestion_job_idx, (ingestion_plan, selector) in enumerate(selectors):
             logger.info(
@@ -263,10 +263,10 @@ class Loader:
                 ingestion_plan.source.provider,
                 ingestion_plan.dataset_type,
             )
-            if cache_key not in existing_timestamps_cache:
-                existing_timestamps_cache[
+            if cache_key not in last_modified_at_cache:
+                last_modified_at_cache[
                     cache_key
-                ] = self.store.get_existing_dataset_timestamps(
+                ] = self.store.get_dataset_last_modified_at_map(
                     provider=cache_key[0],
                     dataset_type=cache_key[1],
                 )
@@ -278,7 +278,7 @@ class Loader:
                 for ingestion_job_summary in ingestion_job.execute(
                     self.store,
                     task_executor=task_executor,
-                    existing_timestamps=existing_timestamps_cache[cache_key],
+                    last_modified_at_map=last_modified_at_cache[cache_key],
                 ):
                     # TODO: handle task_summaries
                     #       Summarize to a IngestionJobSummary, and save to a database. This Summary can later be used in a

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -240,6 +240,11 @@ class Loader:
     def run(self, selectors, dry_run: bool = False):
         """Execute the collected selectors."""
         ingestion_job_prefix = str(uuid.uuid1())
+
+        # Build a cache of existing dataset timestamps per (provider, dataset_type).
+        # Used as a fast pre-check to skip datasets that are already up-to-date.
+        existing_timestamps_cache: dict[tuple, dict] = {}
+
         for ingestion_job_idx, (ingestion_plan, selector) in enumerate(selectors):
             logger.info(
                 f"Discovering datasets from {ingestion_plan.source.__class__.__name__} using selector {selector}"
@@ -253,12 +258,27 @@ class Loader:
                 selector=selector,
             )
 
+            # Lazily load the timestamps cache per (provider, dataset_type)
+            cache_key = (
+                ingestion_plan.source.provider,
+                ingestion_plan.dataset_type,
+            )
+            if cache_key not in existing_timestamps_cache:
+                existing_timestamps_cache[
+                    cache_key
+                ] = self.store.get_existing_dataset_timestamps(
+                    provider=cache_key[0],
+                    dataset_type=cache_key[1],
+                )
+
             with TaskExecutor(
                 dry_run=dry_run,
                 processes=ingestion_plan.source.max_concurrency,
             ) as task_executor:
                 for ingestion_job_summary in ingestion_job.execute(
-                    self.store, task_executor=task_executor
+                    self.store,
+                    task_executor=task_executor,
+                    existing_timestamps=existing_timestamps_cache[cache_key],
                 ):
                     # TODO: handle task_summaries
                     #       Summarize to a IngestionJobSummary, and save to a database. This Summary can later be used in a

--- a/ingestify/application/loader.py
+++ b/ingestify/application/loader.py
@@ -243,7 +243,7 @@ class Loader:
 
         # Build a cache of existing dataset timestamps per (provider, dataset_type).
         # Used as a fast pre-check to skip datasets that are already up-to-date.
-        last_modified_at_cache: dict[tuple, dict] = {}
+        last_modified_at_cache: dict[tuple, "DatasetLastModifiedAtMap"] = {}
 
         for ingestion_job_idx, (ingestion_plan, selector) in enumerate(selectors):
             logger.info(

--- a/ingestify/domain/models/dataset/dataset.py
+++ b/ingestify/domain/models/dataset/dataset.py
@@ -11,6 +11,9 @@ from .revision import Revision, RevisionSource, SourceType
 from ..base import BaseModel
 
 
+DatasetLastModifiedAtMap = dict[str, datetime]
+
+
 class Dataset(BaseModel):
     bucket: str  # This must be set by the DatasetRepository
     dataset_id: str

--- a/ingestify/domain/models/dataset/dataset_repository.py
+++ b/ingestify/domain/models/dataset/dataset_repository.py
@@ -7,6 +7,8 @@ from .dataset import Dataset
 from .dataset_state import DatasetState
 from .selector import Selector
 
+DatasetLastModifiedAtMap = dict[str, datetime]
+
 
 class DatasetRepository(ABC):
     @abstractmethod
@@ -29,7 +31,7 @@ class DatasetRepository(ABC):
         bucket: str,
         provider: str,
         dataset_type: str,
-    ) -> dict[str, datetime]:
+    ) -> DatasetLastModifiedAtMap:
         """Return {identifier_json: last_modified_at} for all datasets matching
         the given provider and dataset_type. Used as a fast pre-check to skip
         datasets that are already up-to-date without loading the full

--- a/ingestify/domain/models/dataset/dataset_repository.py
+++ b/ingestify/domain/models/dataset/dataset_repository.py
@@ -24,7 +24,7 @@ class DatasetRepository(ABC):
     ) -> DatasetCollection:
         pass
 
-    def get_existing_dataset_timestamps(
+    def get_dataset_last_modified_at_map(
         self,
         bucket: str,
         provider: str,

--- a/ingestify/domain/models/dataset/dataset_repository.py
+++ b/ingestify/domain/models/dataset/dataset_repository.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Optional, List, Union
 
 from .collection import DatasetCollection
@@ -22,6 +23,18 @@ class DatasetRepository(ABC):
         page_size: Optional[int] = None,
     ) -> DatasetCollection:
         pass
+
+    def get_existing_dataset_timestamps(
+        self,
+        bucket: str,
+        provider: str,
+        dataset_type: str,
+    ) -> dict[str, datetime]:
+        """Return {identifier_json: last_modified_at} for all datasets matching
+        the given provider and dataset_type. Used as a fast pre-check to skip
+        datasets that are already up-to-date without loading the full
+        dataset+revision+file graph."""
+        return {}
 
     @abstractmethod
     def destroy(self, dataset: Dataset):

--- a/ingestify/domain/models/dataset/dataset_repository.py
+++ b/ingestify/domain/models/dataset/dataset_repository.py
@@ -3,11 +3,9 @@ from datetime import datetime
 from typing import Optional, List, Union
 
 from .collection import DatasetCollection
-from .dataset import Dataset
+from .dataset import Dataset, DatasetLastModifiedAtMap
 from .dataset_state import DatasetState
 from .selector import Selector
-
-DatasetLastModifiedAtMap = dict[str, datetime]
 
 
 class DatasetRepository(ABC):

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -24,6 +24,7 @@ from ingestify.domain.models.resources.dataset_resource import (
     DatasetResource,
 )
 from ingestify.domain.models.resources.batch_loader import BatchLoader
+from ingestify.domain.models.dataset.dataset_repository import DatasetLastModifiedAtMap
 from ingestify.domain.models.task.task_summary import TaskSummary
 from ingestify.exceptions import SaveError, IngestifyError
 from ingestify.utils import TaskExecutor, chunker
@@ -349,7 +350,7 @@ class IngestionJob:
         self,
         store: DatasetStore,
         task_executor: TaskExecutor,
-        last_modified_at_map: Optional[dict] = None,
+        last_modified_at_map: Optional[DatasetLastModifiedAtMap] = None,
     ) -> Iterator[IngestionJobSummary]:
         is_first_chunk = True
         ingestion_job_summary = IngestionJobSummary.new(ingestion_job=self)

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -24,7 +24,7 @@ from ingestify.domain.models.resources.dataset_resource import (
     DatasetResource,
 )
 from ingestify.domain.models.resources.batch_loader import BatchLoader
-from ingestify.domain.models.dataset.dataset_repository import DatasetLastModifiedAtMap
+from ingestify.domain.models.dataset.dataset import DatasetLastModifiedAtMap
 from ingestify.domain.models.task.task_summary import TaskSummary
 from ingestify.exceptions import SaveError, IngestifyError
 from ingestify.utils import TaskExecutor, chunker

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -346,7 +346,10 @@ class IngestionJob:
         self.selector = selector
 
     def execute(
-        self, store: DatasetStore, task_executor: TaskExecutor
+        self,
+        store: DatasetStore,
+        task_executor: TaskExecutor,
+        existing_timestamps: Optional[dict] = None,
     ) -> Iterator[IngestionJobSummary]:
         is_first_chunk = True
         ingestion_job_summary = IngestionJobSummary.new(ingestion_job=self)
@@ -429,12 +432,42 @@ class IngestionJob:
                 yield ingestion_job_summary
                 return
 
+            # Fast pre-check: skip datasets that are definitely up-to-date
+            # based on the cached timestamps. Only resources that might need
+            # work proceed to the full get_dataset_collection check.
+            skipped_tasks = 0
+            if existing_timestamps:
+                pending_batch = []
+                for dataset_resource in batch:
+                    identifier = Identifier.create_from_selector(
+                        self.selector, **dataset_resource.dataset_resource_id
+                    )
+                    ts = existing_timestamps.get(identifier.key)
+                    if ts is not None:
+                        # Dataset exists — check if all files are up-to-date
+                        max_file_modified = max(
+                            f.last_modified for f in dataset_resource.files.values()
+                        )
+                        if ts >= max_file_modified:
+                            skipped_tasks += 1
+                            continue
+                    pending_batch.append(dataset_resource)
+                batch = pending_batch
+
+            if not batch:
+                logger.info(
+                    f"Discovered {skipped_tasks + len(batch)} datasets from "
+                    f"{self.ingestion_plan.source.__class__.__name__} "
+                    f"using selector {self.selector} => nothing to do "
+                    f"({skipped_tasks} skipped via pre-check)"
+                )
+                ingestion_job_summary.increase_skipped_tasks(skipped_tasks)
+                continue
+
             dataset_identifiers = [
                 Identifier.create_from_selector(
                     self.selector, **dataset_resource.dataset_resource_id
                 )
-                # We have to pass the data_spec_versions here as a Source can add some
-                # extra data to the identifier which is retrieved in a certain data format
                 for dataset_resource in batch
             ]
 
@@ -448,8 +481,6 @@ class IngestionJob:
                     provider=batch[0].provider,
                     selector=dataset_identifiers,
                 )
-
-            skipped_tasks = 0
 
             task_set = TaskSet()
 

--- a/ingestify/domain/models/ingestion/ingestion_job.py
+++ b/ingestify/domain/models/ingestion/ingestion_job.py
@@ -349,7 +349,7 @@ class IngestionJob:
         self,
         store: DatasetStore,
         task_executor: TaskExecutor,
-        existing_timestamps: Optional[dict] = None,
+        last_modified_at_map: Optional[dict] = None,
     ) -> Iterator[IngestionJobSummary]:
         is_first_chunk = True
         ingestion_job_summary = IngestionJobSummary.new(ingestion_job=self)
@@ -436,13 +436,13 @@ class IngestionJob:
             # based on the cached timestamps. Only resources that might need
             # work proceed to the full get_dataset_collection check.
             skipped_tasks = 0
-            if existing_timestamps:
+            if last_modified_at_map:
                 pending_batch = []
                 for dataset_resource in batch:
                     identifier = Identifier.create_from_selector(
                         self.selector, **dataset_resource.dataset_resource_id
                     )
-                    ts = existing_timestamps.get(identifier.key)
+                    ts = last_modified_at_map.get(identifier.key)
                     if ts is not None:
                         # Dataset exists — check if all files are up-to-date
                         max_file_modified = max(

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 import logging
 import uuid
 from typing import Optional, Union, List
@@ -38,7 +39,7 @@ from ingestify.domain.models.dataset.collection_metadata import (
 from ingestify.domain.models.ingestion.ingestion_job_summary import IngestionJobSummary
 from ingestify.domain.models.task.task_summary import TaskSummary
 from ingestify.exceptions import IngestifyError
-from ingestify.utils import get_concurrency
+from ingestify.utils import get_concurrency, key_from_dict
 
 from .tables import get_tables
 
@@ -515,6 +516,31 @@ class SqlAlchemyDatasetRepository(DatasetRepository):
             compile_kwargs={"literal_binds": True}, dialect=self.dialect
         )
         logger.debug(f"Running query: {text_}")
+
+    def get_existing_dataset_timestamps(
+        self,
+        bucket: str,
+        provider: str,
+        dataset_type: str,
+    ) -> dict:
+        with self.session:
+            query = (
+                self.session.query(
+                    self.dataset_table.c.identifier,
+                    self.dataset_table.c.last_modified_at,
+                )
+                .filter(self.dataset_table.c.bucket == bucket)
+                .filter(self.dataset_table.c.provider == provider)
+                .filter(self.dataset_table.c.dataset_type == dataset_type)
+            )
+            return {
+                key_from_dict(
+                    row.identifier
+                    if isinstance(row.identifier, dict)
+                    else json.loads(row.identifier)
+                ): row.last_modified_at
+                for row in query
+            }
 
     def get_dataset_collection(
         self,

--- a/ingestify/infra/store/dataset/sqlalchemy/repository.py
+++ b/ingestify/infra/store/dataset/sqlalchemy/repository.py
@@ -517,7 +517,7 @@ class SqlAlchemyDatasetRepository(DatasetRepository):
         )
         logger.debug(f"Running query: {text_}")
 
-    def get_existing_dataset_timestamps(
+    def get_dataset_last_modified_at_map(
         self,
         bucket: str,
         provider: str,

--- a/ingestify/tests/test_fast_skip.py
+++ b/ingestify/tests/test_fast_skip.py
@@ -50,11 +50,11 @@ def _setup(engine):
 
 
 def test_timestamps_cache_matches_identifiers(engine):
-    """Keys from get_existing_dataset_timestamps match Identifier.key."""
+    """Keys from get_dataset_last_modified_at_map match Identifier.key."""
     _setup(engine)
     engine.run()
 
-    timestamps = engine.store.get_existing_dataset_timestamps(
+    timestamps = engine.store.get_dataset_last_modified_at_map(
         provider="test_provider", dataset_type="test"
     )
     datasets = engine.store.get_dataset_collection(

--- a/ingestify/tests/test_fast_skip.py
+++ b/ingestify/tests/test_fast_skip.py
@@ -1,0 +1,66 @@
+"""Tests for fast skip pre-check."""
+from ingestify import Source, DatasetResource
+from ingestify.domain import DataSpecVersionCollection, DraftFile, Selector
+from ingestify.domain.models.dataset.collection_metadata import (
+    DatasetCollectionMetadata,
+)
+from ingestify.domain.models.fetch_policy import FetchPolicy
+from ingestify.domain.models.ingestion.ingestion_plan import IngestionPlan
+from ingestify.utils import utcnow
+
+
+def loader(file_resource, current_file, **kwargs):
+    return DraftFile.from_input("data", data_feed_key="f1")
+
+
+class SimpleSource(Source):
+    provider = "test_provider"
+
+    def find_datasets(
+        self, dataset_type, data_spec_versions, dataset_collection_metadata, **kwargs
+    ):
+        for i in range(5):
+            r = DatasetResource(
+                dataset_resource_id={"item_id": i},
+                provider=self.provider,
+                dataset_type="test",
+                name=f"item-{i}",
+            )
+            r.add_file(
+                last_modified=utcnow(),
+                data_feed_key="f1",
+                data_spec_version="v1",
+                file_loader=loader,
+            )
+            yield r
+
+
+def _setup(engine):
+    source = SimpleSource("s")
+    dsv = DataSpecVersionCollection.from_dict({"default": {"v1"}})
+    engine.add_ingestion_plan(
+        IngestionPlan(
+            source=source,
+            fetch_policy=FetchPolicy(),
+            dataset_type="test",
+            selectors=[Selector.build({}, data_spec_versions=dsv)],
+            data_spec_versions=dsv,
+        )
+    )
+
+
+def test_timestamps_cache_matches_identifiers(engine):
+    """Keys from get_existing_dataset_timestamps match Identifier.key."""
+    _setup(engine)
+    engine.run()
+
+    timestamps = engine.store.get_existing_dataset_timestamps(
+        provider="test_provider", dataset_type="test"
+    )
+    datasets = engine.store.get_dataset_collection(
+        provider="test_provider", dataset_type="test"
+    )
+
+    assert len(timestamps) == len(datasets) == 5
+    for dataset in datasets:
+        assert dataset.identifier.key in timestamps


### PR DESCRIPTION
Before processing batches, loads a lightweight {identifier_key: last_modified_at} dict from the database in a single query (no joins to revision/file tables). Datasets where last_modified_at >= max(file.last_modified) are skipped instantly without the expensive get_dataset_collection call.

The cache is built once per (provider, dataset_type) in the loader and reused across selectors within the same run.

No false negatives: datasets that might need updating always fall through to the full should_refetch check.