### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/ingestify/__init__.py
+++ b/ingestify/__init__.py
@@ -11,4 +11,4 @@ if not __INGESTIFY_SETUP__:
     from .exceptions import StopProcessing, FatalError
     from .main import debug_source
 
-__version__ = "0.17.1"
+__version__ = "0.18.0"


### PR DESCRIPTION
Minor release: live ingestion job summary (RUNNING snapshots), FatalError (fail loudly, exit 1, summary persisted), DatasetResource.mark_failed. All additive / backward compatible.